### PR TITLE
Update README with link to vim-cljfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ As with the `check` task, you can choose to fix a specific file:
 
     lein cljfmt fix src/foo/core.clj
 
+## Editor Support
+
+* [vim-cljfmt](https://github.com/venantius/vim-cljfmt)
+
 ## Configuration
 
 You can configure lein-cljfmt by adding a `:cljfmt` map to your


### PR DESCRIPTION
Adds an Editor Support section, with just a link to vim-cljfmt for now.