### PR TITLE
Anchor file-pattern regex so as to not match .swp

### DIFF
--- a/lein-cljfmt/src/leiningen/cljfmt.clj
+++ b/lein-cljfmt/src/leiningen/cljfmt.clj
@@ -10,7 +10,7 @@
   (filter #(re-find re (str %)) (file-seq (io/file dir))))
 
 (defn file-pattern [project]
-  (get-in project [:cljfmt :file-pattern] #"\.clj[sx]?"))
+  (get-in project [:cljfmt :file-pattern] #"\.clj[sx]?$"))
 
 (defn find-files [project f]
   (let [f (io/file f)]


### PR DESCRIPTION
cljfmt would on occasion not play nicely with editor tempfiles. I see no reason not to anchor the regex, but perhaps I'm missing a usecase? 