### PR TITLE
Add clojurescript support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: clojure
-before_install: cd cljfmt
+before_install: yes | sudo lein upgrade && cd cljfmt

--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -4,5 +4,18 @@
   :scm {:dir ".."}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [rewrite-clj "0.4.12"]])
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/clojurescript "1.7.228"]
+                 [rewrite-clj "0.4.12"]
+                 [rewrite-cljs "0.4.0"]]
+  :plugins [[lein-cljsbuild "1.1.2"]]
+  :hooks [leiningen.cljsbuild]
+  :cljsbuild {:builds
+              {"dev" {:source-paths ["src" "test"]
+                      :compiler {:main cljfmt.test-runner
+                                 :output-to "target/out/tests.js"
+                                 :output-dir "target/out"
+                                 :target :nodejs
+                                 :optimizations :none}}}
+              :test-commands
+              {"dev" ["node" "target/out/tests.js"]}})

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -1,6 +1,7 @@
 (ns cljfmt.core-test
-  (:require [clojure.test :refer :all]
-            [cljfmt.core :refer :all]))
+  (:require [#?@(:clj (clojure.test :refer)
+                 :cljs (cljs.test :refer-macros)) [deftest testing is]]
+            [cljfmt.core :refer [reformat-string]]))
 
 (deftest test-indent
   (testing "list indentation"

--- a/cljfmt/test/cljfmt/test_runner.cljs
+++ b/cljfmt/test/cljfmt/test_runner.cljs
@@ -1,0 +1,11 @@
+(ns cljfmt.test-runner
+  (:require [cljs.nodejs :as nodejs]
+            [cljs.test :refer-macros [run-tests]]
+            [cljfmt.core-test :as ct]))
+
+(nodejs/enable-util-print!)
+
+(defn -main []
+  (run-tests 'cljfmt.core-test))
+
+(set! *main-cli-fn* -main)


### PR DESCRIPTION
Closes #52 

Some notes:
- tests in both clj and cljs can be run with `lein test`
- I'm not 100% sure what `z/value` was doing - it's deprecated in both clj and cljs but I think with the `when` guard just using `sexpr` is safe.
- The macro inlines the resources directly into javascript.
- Since the cljs rewrite port has functions in slightly different namespaces I used a combination of `def` and `refer` to minimize the number of reader conditionals.