### PR TITLE
Standalone check and format

### DIFF
--- a/lein-cljfmt/src/leiningen/cljfmt.clj
+++ b/lein-cljfmt/src/leiningen/cljfmt.clj
@@ -36,7 +36,7 @@
       (.getPath)))
 
 (defn project-path [project file]
-  (relative-path (io/file (:root project)) (io/file file)))
+  (relative-path (io/file (:root project ".")) (io/file file)))
 
 (defn format-diff [project file]
   (let [filename (project-path project file)
@@ -57,7 +57,9 @@
 
 (defn check
   ([project]
-   (apply check project (format-paths project)))
+   (if project
+     (apply check project (format-paths project))
+     (main/abort "No project found and no source paths provided")))
   ([project path & paths]
    (let [files   (mapcat (partial find-files project) (cons path paths))
          invalid (remove (partial valid-format? project) files)]
@@ -71,14 +73,16 @@
 
 (defn fix
   ([project]
-   (apply fix project (format-paths project)))
+   (if project
+     (apply fix project (format-paths project))
+     (main/abort "No project found and no source paths provided")))
   ([project path & paths]
    (let [files (mapcat (partial find-files project) (cons path paths))]
      (doseq [f files :when (not (valid-format? project f))]
        (main/info "Reformatting" (project-path project f))
        (spit f (reformat-string project (slurp f)))))))
 
-(defn cljfmt
+(defn ^:no-project-needed cljfmt
   "Format Clojure source files"
   [project command & args]
   (case command


### PR DESCRIPTION
This changeset tweaks cljfmt so that it can be run outside of a Leiningen project so long as one or more source paths are provided.

Fixes #50