### PR TITLE
Format once

### DIFF
--- a/lein-cljfmt/src/leiningen/cljfmt.clj
+++ b/lein-cljfmt/src/leiningen/cljfmt.clj
@@ -26,10 +26,6 @@
 (defn reformat-string [project s]
   (cljfmt/reformat-string s (meta-merge default-config (:cljfmt project {}))))
 
-(defn valid-format? [project file]
-  (let [content (slurp (io/file file))]
-    (= content (reformat-string project content))))
-
 (defn relative-path [dir file]
   (-> (.toURI dir)
       (.relativize (.toURI file))

--- a/lein-cljfmt/src/leiningen/cljfmt.clj
+++ b/lein-cljfmt/src/leiningen/cljfmt.clj
@@ -81,9 +81,12 @@
    (apply fix project (format-paths project)))
   ([project path & paths]
    (let [files (mapcat (partial find-files project) (cons path paths))]
-     (doseq [f files :when (not (valid-format? project f))]
+     (doseq [f     files
+             :let  [original (slurp f)
+                    revised  (reformat-string project original)]
+             :when (not= original revised)]
        (main/info "Reformatting" (project-path project f))
-       (spit f (reformat-string project (slurp f)))))))
+       (spit f revised)))))
 
 (defn cljfmt
   "Format Clojure source files"


### PR DESCRIPTION
This patch fixes #55, by inlining the `valid-format?` check and tweaking diff generation so that files are never read or formatted twice. This gives the expected 50% speedup.

before:
> lein cljfmt fix src/clj  772.30s user 1.78s system 101% cpu 12:41.43 total

after:
> lein cljfmt fix src/clj  396.35s user 1.40s system 103% cpu 6:23.34 total

merges cleanly with #54 