### PR TITLE
prior-string optimization

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -8,10 +8,11 @@
          [rewrite-clj.zip :as z
           :refer [append-space edn skip whitespace-or-comment?]])
         (:import java.util.regex.Pattern)]
-       :cljs
+      :cljs
        [(:require
          [cljs.reader :as reader]
          [clojure.zip :as zip]
+         [clojure.string :as str]
          [rewrite-clj.node :as n]
          [rewrite-clj.parser :as p]
          [rewrite-clj.zip :as z]
@@ -28,6 +29,10 @@
 
 (def zlinebreak?
   #?(:clj z/linebreak? :cljs zw/linebreak?))
+
+(def includes?
+  #?(:clj  (fn [^String a ^String b] (.contains a b))
+     :cljs str/includes?))
 
 (defn- edit-all [zloc p? f]
   (loop [zloc (if (p? zloc) (f zloc) zloc)]
@@ -118,20 +123,25 @@
    :set "#{", :deref "@",  :reader-macro "#", :unquote "~"
    :var "#'", :quote "'",  :syntax-quote "`", :unquote-splicing "~@"})
 
-(defn- prior-string [zloc]
+(defn- prior-line-string [zloc]
   (loop [zloc     zloc
          worklist '()]
     (if-let [p (zip/left zloc)]
-      (recur p (cons (n/string (z/node p)) worklist))
+      (let [s            (str (n/string (z/node p)))
+            new-worklist (cons s worklist)]
+        (if-not (includes? s "\n")
+          (recur p new-worklist)
+          (apply str new-worklist)))
       (if-let [p (zip/up zloc)]
-        (recur p  (cons (start-element (n/tag (z/node p))) worklist))
+        ;; newline cannot be introduced by start-element
+        (recur p (cons (start-element (n/tag (z/node p))) worklist))
         (apply str worklist)))))
 
 (defn- last-line-in-string [^String s]
   (subs s (inc (.lastIndexOf s "\n"))))
 
 (defn- margin [zloc]
-  (-> zloc prior-string last-line-in-string count))
+  (-> zloc prior-line-string last-line-in-string count))
 
 (defn- whitespace [width]
   (n/whitespace-node (apply str (repeat width " "))))

--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -119,11 +119,13 @@
    :var "#'", :quote "'",  :syntax-quote "`", :unquote-splicing "~@"})
 
 (defn- prior-string [zloc]
-  (if-let [p (zip/left zloc)]
-    (str (prior-string p) (n/string (z/node p)))
-    (if-let [p (zip/up zloc)]
-      (str (prior-string p) (start-element (n/tag (z/node p))))
-      "")))
+  (loop [zloc     zloc
+         worklist '()]
+    (if-let [p (zip/left zloc)]
+      (recur p (cons (n/string (z/node p)) worklist))
+      (if-let [p (zip/up zloc)]
+        (recur p  (cons (start-element (n/tag (z/node p))) worklist))
+        (apply str worklist)))))
 
 (defn- last-line-in-string [^String s]
   (subs s (inc (.lastIndexOf s "\n"))))

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -119,7 +119,11 @@
   (testing "indentated forms in letfn block"
     (is (= (reformat-string "(letfn [(f [x]\nx)]\n(let [x (f 1)]\n(str x 2\n3 4)))")
            (str "(letfn [(f [x]\n          x)]\n"
-                "  (let [x (f 1)]\n    (str x 2\n         3 4)))")))))
+                "  (let [x (f 1)]\n    (str x 2\n         3 4)))"))))
+
+  (testing "miltiline right hand side forms"
+    (is (= (reformat-string "(list foo :bar (fn a\n([] nil)\n([b] b)))")
+           "(list foo :bar (fn a\n                 ([] nil)\n                 ([b] b)))"))))
 
 (deftest test-surrounding-whitespace
   (testing "surrounding spaces"


### PR DESCRIPTION
`prior-string` as written is left recursive and operates by concatenating a series of generated strings. `clojure.core/str` internally uses a `java.lang.StringBuilder` which is a fast right-concatenative structure. The structural left recursion of `prior-string` meant that for `n` recursive calls `n-1` intermediate `StringBuilder`s would be created and finalized to `String`s, the the resulting immutable `String` would be copied in full and discarded in the parent.

This patch uses the insight that this structural left recursion can be rewritten into a flat `recur` loop by accumulating zipper nodes previously concatenated on the right in a worklist which grows right to
left (immutable cons/push front) and then in the base case making a single pass over this worklist with a single `StringBuilder` to generate the result string in a single pass without intermediary structures.

This change alone brings the format time on clojure/core.clj down from 7 minutes to 2.