### PR TITLE
Add option to remove trailing whitespace

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -273,6 +273,19 @@
   ([form indents]
    (indent (unindent form) indents)))
 
+(defn root? [zloc]
+  (nil? (zip/up zloc)))
+
+(defn final? [zloc]
+  (and (nil? (zip/right zloc)) (root? (zip/up zloc))))
+
+(defn- trailing-whitespace? [zloc]
+ (and (whitespace? zloc)
+      (or (zlinebreak? (zip/right zloc)) (final? zloc))))
+
+(defn remove-trailing-whitespace [form]
+  (transform form edit-all trailing-whitespace? zip/remove))
+
 (defn reformat-form
   [form & [{:as opts}]]
   (-> form
@@ -283,7 +296,9 @@
       (cond-> (:insert-missing-whitespace? opts true)
         insert-missing-whitespace)
       (cond-> (:indentation? opts true)
-        (reindent (:indents opts default-indents)))))
+        (reindent (:indents opts default-indents)))
+      (cond-> (:remove-trailing-whitespace? opts true)
+        remove-trailing-whitespace)))
 
 (defn reformat-string [form-string & [options]]
   (-> (p/parse-string-all form-string)

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -172,6 +172,26 @@
   (is (= (reformat-string "(foo)\n;bar\n;baz\n;qux\n(bang)")
          "(foo)\n;bar\n;baz\n;qux\n(bang)")))
 
+(deftest test-trailing-whitespace
+  (testing "trailing-whitespace"
+    (is (= (reformat-string "(foo bar) ")
+           "(foo bar)"))
+    (is (= (reformat-string "(foo bar)\n")
+           "(foo bar)\n"))
+    (is (= (reformat-string "(foo bar) \n ")
+           "(foo bar)\n"))
+    (is (= (reformat-string "(foo bar) \n(foo baz)")
+           "(foo bar)\n(foo baz)"))
+    (is (= (reformat-string "(foo bar)\t\n(foo baz)")
+           "(foo bar)\n(foo baz)")))
+
+  (testing "preserve surrounding whitespace"
+    (is (= (reformat-string "( foo bar ) \n" {:remove-surrounding-whitespace? false})
+           "( foo bar )\n"))
+    (is (= (reformat-string
+            "( foo bar )   \n( foo baz )\n" {:remove-surrounding-whitespace? false})
+           "( foo bar )\n( foo baz )\n"))))
+
 (deftest test-options
   (is (= (reformat-string "(foo)\n\n\n(bar)" {:remove-consecutive-blank-lines? false})
          "(foo)\n\n\n(bar)"))
@@ -184,7 +204,11 @@
   (is (= (reformat-string "(do\nfoo\nbar)" {:indents {}})
          "(do\n foo\n bar)"))
   (is (= (reformat-string "(do\nfoo\nbar)" {:indentation? false})
-         "(do\nfoo\nbar)")))
+         "(do\nfoo\nbar)"))
+  (is (= (reformat-string "(foo bar) \n(foo baz)" {:remove-trailing-whitespace? false})
+         "(foo bar) \n(foo baz)"))
+  (is (= (reformat-string "(foo bar) \n" {:remove-trailing-whitespace? false})
+         "(foo bar) \n")))
 
 (deftest test-parsing
   (is (= (reformat-string ";foo") ";foo"))


### PR DESCRIPTION
The implementation respects the surrounding whitespace and handles whitespace at the end of the string for cases where I would expect it is desired. Note that I am new to the codebase, open to feedback if I missed something.