### PR TITLE
Don't add whitespace after reader conditionals

### DIFF
--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -6,8 +6,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.reader "1.0.0-alpha4"]
-                 [rewrite-clj "0.4.12"]
-                 [rewrite-cljs "0.4.1"]]
+                 [rewrite-clj "0.5.2"]
+                 [rewrite-cljs "0.4.2"]]
   :plugins [[lein-cljsbuild "1.1.2"]]
   :hooks [leiningen.cljsbuild]
   :cljsbuild {:builds

--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -60,8 +60,13 @@
 (defn- element? [zloc]
   (if zloc (not (whitespace-or-comment? zloc))))
 
+(defn- reader-macro? [zloc]
+  (when zloc (= (n/tag (z/node zloc)) :reader-macro)))
+
 (defn- missing-whitespace? [zloc]
-  (and (element? zloc) (element? (zip/right zloc))))
+  (and
+    (and (element? zloc) (not (reader-macro? (zip/up zloc))))
+    (element? (zip/right zloc))))
 
 (defn insert-missing-whitespace [form]
   (transform form edit-all missing-whitespace? append-space))

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -158,6 +158,12 @@
   (is (= (reformat-string "(foo[bar]#{baz}{quz bang})")
          "(foo [bar] #{baz} {quz bang})")))
 
+(deftest missing-whitespace-reader-conditionals
+  (is (= (reformat-string "#?(:cljs(bar 1) :clj(foo 2))")
+         "#?(:cljs (bar 1) :clj (foo 2))"))
+  (is (= (reformat-string "#?@(:cljs[foo bar] :clj[baz quux])")
+         "#?@(:cljs [foo bar] :clj [baz quux])")))
+
 (deftest test-consecutive-blank-lines
   (is (= (reformat-string "(foo)\n\n(bar)")
          "(foo)\n\n(bar)"))


### PR DESCRIPTION
This updates `rewrite-clj` & `rewrite-cljs` to newest versions and restricts missing whitespace check for reader conditionals.