### PR TITLE
Follow style guide for as->

### DIFF
--- a/cljfmt/resources/cljfmt/indents/clojure.clj
+++ b/cljfmt/resources/cljfmt/indents/clojure.clj
@@ -1,6 +1,7 @@
 {alt!            [[:block 0]]
  alt!!           [[:block 0]]
  are             [[:block 2]]
+ as->            [[:block 2]]
  binding         [[:block 1]]
  bound-fn        [[:inner 0]]
  case            [[:block 1]]


### PR DESCRIPTION
as-> has two special arguments: the expression being bound, and the name being introduced inside the body of the threading. This gives it the correct indentation.

Before:

```clojure
(as->> 1 $
       (inc $)
       (* 2 $))
```

After:

```clojure
(as->> 1 $
  (inc $)
  (* 2 $))
```