### PR TITLE
Only filter the portion of filename within project

### DIFF
--- a/lein-cljfmt/src/leiningen/cljfmt.clj
+++ b/lein-cljfmt/src/leiningen/cljfmt.clj
@@ -8,8 +8,13 @@
             [leiningen.cljfmt.diff :as diff]
             [meta-merge.core :refer [meta-merge]]))
 
+(defn relative-path [dir file]
+  (-> (.toURI dir)
+      (.relativize (.toURI file))
+      (.getPath)))
+
 (defn grep [re dir]
-  (filter #(re-find re (str %)) (file-seq (io/file dir))))
+  (filter #(re-find re (relative-path dir %)) (file-seq (io/file dir))))
 
 (defn file-pattern [project]
   (get-in project [:cljfmt :file-pattern] #"\.clj[sx]?$"))
@@ -26,11 +31,6 @@
 
 (defn reformat-string [project s]
   (cljfmt/reformat-string s (meta-merge default-config (:cljfmt project {}))))
-
-(defn relative-path [dir file]
-  (-> (.toURI dir)
-      (.relativize (.toURI file))
-      (.getPath)))
 
 (defn project-path [project file]
   (relative-path (io/file (:root project ".")) (io/file file)))


### PR DESCRIPTION
The current version applies the regex against the entire filename,
meaning that it can have different behaviour for people depending on
their local directory structure. By removing the parent directory name,
we make the behaviour more repeatable.

Consider a repo with this structure:

    foo/src/org/foo/bar.clj
    foo/test/org/foo/bar_test.clj

If you want to apply the formatting only to files under the src folder,
you might write this regex:

    #"src/.+\.clj[csx]?$"

We want it to indent bar.clj but not bar_test.clj.

However, imagine two different developers have this repo, and they store
their code in different directories:

    Dev 1: ~/code/foo
    Dev 2: ~/src/foo

For Dev 1, the regex above will work correctly. However, for Dev 2, the
regex will seem "broken" - bar_test.clj will still be indented! And
that's because it's matching the parent directory of src.

Removing the parent directory before matching avoids the influence of
the local directory structure on a given machine.