### PR TITLE
Add failing test for post-comment indentation

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -1,7 +1,8 @@
 (ns cljfmt.core-test
   (:require [#?@(:clj (clojure.test :refer)
                  :cljs (cljs.test :refer-macros)) [deftest testing is]]
-            [cljfmt.core :refer [reformat-string]]))
+            [cljfmt.core :refer [reformat-string]]
+            [clojure.string :as str]))
 
 (deftest test-indent
   (testing "list indentation"
@@ -105,6 +106,23 @@
            "(defelem foo [x]\n  [:foo x])")))
 
   (testing "comment before ending bracket"
+    (is (= (->> ["(defn foo"
+                 "  []"
+                 "  (let [x 1]"
+                 "    ;; test1"
+                 "    )"
+                 "  ;; test2"
+                 "  )"]
+                (str/join "\n")
+                reformat-string
+                str/split-lines)
+           ["(defn foo"
+            "  []"
+            "  (let [x 1]"
+            "    ;; test1"
+            "    )"
+            "  ;; test2"
+            "  )"]))
     (is (= (reformat-string "(foo a ; b\nc ; d\n)")
            "(foo a ; b\n     c ; d\n     )"))
     (is (= (reformat-string "(do\na ; b\nc ; d\n)")


### PR DESCRIPTION
Hey @weavejester,

I've noticed the logic for indenting comments nested inside a `let` within a `defn` is slightly off (as has been reported via #82).

I added a test to demonstrate the issue, but fixing will take a little longer as I'm not at all familiar with the code. I might have some time tomorrow though, and will hopefully fix things.

Hope you're well,

James