### PR TITLE
Make indent settings available at runtime

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -22,6 +22,9 @@
           :refer [append-space skip whitespace-or-comment?]])
         (:require-macros [cljfmt.core :refer [read-resource]])]))
 
+(def project-settings-store (atom {}))
+(defn project-settings [] @project-settings-store)
+
 #?(:clj (def read-resource* (comp read-string slurp io/resource)))
 #?(:clj (defmacro read-resource [path] `'~(read-resource* path)))
 

--- a/lein-cljfmt/src/lein_cljfmt/plugin.clj
+++ b/lein-cljfmt/src/lein_cljfmt/plugin.clj
@@ -1,0 +1,10 @@
+(ns lein-cljfmt.plugin)
+
+(defn middleware [project]
+  (let [settings (:cljfmt project)]
+    (if (:in-runtime settings)
+      (update-in
+        project [:injections] concat
+        `[(require 'cljfmt.core)
+          (reset! cljfmt.core/project-settings-store (quote ~settings))])  
+      project)))


### PR DESCRIPTION
vim-cljfmt uses a REPL connection to call reformat-string and reformat vim
buffers on command. Unfortunately, it doesn't respect indent options specified
in project.clj/profiles.clj. As mentioned in venantius/vim-cljfmt#24 the author
is reluctant to parse these files manually.

By injecting indent settings into cljfmt.core at REPL startup, we can enable
vim-cljfmt to easily respect these settings.