### PR TITLE
Mention clojureVSCode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ As with the `check` task, you can choose to fix a specific file:
 
 * [vim-cljfmt](https://github.com/venantius/vim-cljfmt)
 * [CIDER 0.9+](https://github.com/clojure-emacs/cider)
+* [clojureVSCode](https://github.com/avli/clojureVSCode)
 
 ## Configuration
 


### PR DESCRIPTION
Since the version 0.8.0 clojureVSCode uses `cljfmt` for formatting Clojure files.