### PR TITLE
Parallel fix and check

### DIFF
--- a/lein-cljfmt/project.clj
+++ b/lein-cljfmt/project.clj
@@ -7,4 +7,5 @@
   :eval-in-leiningen true
   :dependencies [[cljfmt "0.5.7"]
                  [meta-merge "1.0.0"]
+                 [org.clojure/core.async "0.3.443"]
                  [com.googlecode.java-diff-utils/diffutils "1.2.1"]])


### PR DESCRIPTION
I noticed that cljfmt was not using all of my cores. Hence this PR.
`time` with latest version (0.5.7):
```
real    59,88s
user    65,32s
sys 0,69s
```
`time` with this PR:
```
real    37,71s
user    104,55s
sys 0,74s
```

There are very likely things to improve in this PR, but at least it got slightly more efficient!

