### PR TITLE
Custom indentation per-namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,48 @@ You can also configure the behavior of cljfmt:
   a map of var symbols to indentation rules, i.e. `{symbol [& rules]}`.
   See the next section for a detailed explanation.
 
-As with Leiningen profiles, you can add metadata hints. If you want to
-override all existing indents, instead of just supplying new indents
-that are merged with the defaults, you can use the `:replace` hint:
+  Unqualified symbols in the indents map will apply to any symbol with a
+  matching "name" - so `foo` would apply to both `org.me/foo` and
+  `com.them/foo`. If you want finer-grained control, you can use a fully
+  qualified symbol in the indents map to configure indentation that
+  applies only to `org.me/foo`:
 
-```clojure
-:cljfmt {:indents ^:replace {#".*" [[:inner 0]]}}
-```
+  ```clojure
+  :cljfmt {:indents {org.me/foo [[:inner 0]]}}
+  ```
+
+  Configured this way, `org.me/foo` will indent differently from
+  `com.them/foo`.
+
+  Note that `cljfmt` currently doesn't resolve symbols brought into a
+  namespace using `:refer` or `:use` - they can only be controlled by an
+  unqualified indent rule.
+
+  As with Leiningen profiles, you can add metadata hints. If you want to
+  override all existing indents, instead of just supplying new indents
+  that are merged with the defaults, you can use the `:replace` hint:
+
+  ```clojure
+  :cljfmt {:indents ^:replace {#".*" [[:inner 0]]}}
+  ```
+
+* `:alias-map` -
+  a map of namespace alias strings to fully qualified namespace
+  names. This option is unnecessary in almost all cases, because
+  `cljfmt` can compute the alias map from an `ns`
+  declaration.
+
+  However, it can't do that when used as a CLJS library,
+  or when indenting something with no `ns` declaration like an EDN
+  file. Even in those situations, you only need this option when using
+  indentation rules that rely on the fully qualified symbol name.
+
+  If you definitely need to configure this, it should look like this:
+
+  ```clojure
+  :cljfmt {:indents {org.me/foo [[:inner 0]]}
+           :alias-map {"me" "org.me"}}
+  ```
 
 
 ### Indentation rules


### PR DESCRIPTION
This PR implements #108, supporting indent rules that apply only to a namespaced symbol. When a namespaced symbol is checked for a matching indent rule, it will check first for a namespaced version, then fall back to the old behaviour if none is found.

## Proof that it works

You can see the [difference in behaviour in this example repo](https://github.com/MatthewDarling/cljfmt-defrecord-formatting-example/compare/namespace-support) - it finds that the `s` alias resolves to `schema.core`, and then uses the `schema.core/defrecord` indentation rules.

## Assorted thoughts about the changes

  * I implemented `find-all` as a way to get a seq of matching nodes in a zipper. This is the sort of thing that I assume someone else has already written, but I can never find it when I need it. Here, it's used to find all the `:as` notices within a `:require` block.
  * `indent-order` now has this ordering: namespaced symbols, all other symbols, regex patterns
  * Adding `alias-map` as an argument to a bunch of functions makes the diff look ugly. Public functions received an extra arity to accept it, or will use a default value. Private functions now require it as a mandatory argument. Likely there's room for improvement here though.
  * I'm not sure the updated documentation belongs where it is. Maybe a separate "advanced configuration settings" section might be good? I tried to be really specific about the niche situations that this functionality is useful. Still, I'm concerned users might reach for this stuff when they don't need it, because it's mixed in with the more basic info.

## CLJS issues

There's already an [open issue about `rewrite-cljs` not fully tracking `rewrite-clj`](https://github.com/weavejester/cljfmt/issues/106), and it bit me here. All the functions used to find aliases inside an `ns` block require some of the missing behaviour.

Could be worked around by using `tools.analyzer` in CLJS for this specific task, or a hacky `map`/`filter`/etc combo, but... it's probably just better for someone to update `rewrite-cljs`.

To get around the issue for now, `format-string` checks its options map for the key `:alias-map`. That way users can manually fill out any aliases they need. Hopefully this workaround isn't necessary for long. Maybe the README should say "help wanted to update `rewrite-cljs`" in the relevant section?