### PR TITLE
When encountering greater than 2 consecutive lines

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -108,7 +108,12 @@
     zloc))
 
 (defn- replace-consecutive-blank-lines [zloc]
-  (-> zloc (zip/replace (n/newlines 2)) zip/next remove-whitespace-and-newlines))
+  (-> zloc
+      z/next
+      zip/prev
+      remove-whitespace-and-newlines
+      z/next
+      (zip/insert-left (n/newlines 2))))
 
 (defn remove-consecutive-blank-lines [form]
   (transform form edit-all consecutive-blank-line? replace-consecutive-blank-lines))

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -211,6 +211,8 @@
 (deftest test-consecutive-blank-lines
   (is (= (reformat-string "(foo)\n\n(bar)")
          "(foo)\n\n(bar)"))
+  (is (= (reformat-string "(foo)\n\n\n (bar)")
+         "(foo)\n\n(bar)"))
   (is (= (reformat-string "(foo)\n\n\n(bar)")
          "(foo)\n\n(bar)"))
   (is (= (reformat-string "(foo)\n \n \n(bar)")


### PR DESCRIPTION
completely wipeout whitespace and newlines before inserting 2 consecutive lines

Addresses #118

Since `remove` moves right to left the `(zip/replace (n/newlines 2))` was getting clobbered by `remove-whitespace-and-newlines`. This slipped through because none of the existing tests had whitespace nodes after `consecutive-blank-line?` was true

