### PR TITLE
Add vscode-cljfmt to 'Editor Support'

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ As with the `check` task, you can choose to fix a specific file:
 
 * [vim-cljfmt](https://github.com/venantius/vim-cljfmt)
 * [CIDER 0.9+](https://github.com/clojure-emacs/cider)
+* [vscode-cljfmt](https://marketplace.visualstudio.com/items?itemName=pedrorgirardi.vscode-cljfmt)
 
 ## Configuration
 


### PR DESCRIPTION
Hi there! I wrote a VS Code extension for `cljfmt`, this PR is just to add that to the **Editor Support**.

Thank you for **cljfmt**!