### PR TITLE
Fixed bug where incorrect file path separator would be used on windows

### DIFF
--- a/cljfmt/src/cljfmt/diff.clj
+++ b/cljfmt/src/cljfmt/diff.clj
@@ -1,6 +1,7 @@
 (ns cljfmt.diff
   (:import [difflib DiffUtils Delta$TYPE]
-           [java.io File])
+           [java.io File]
+           [java.util.regex Pattern])
   (:require [clojure.java.io :as io]
             [clojure.string :as str]))
 
@@ -11,7 +12,7 @@
   (str/join "\n" ss))
 
 (defn to-absolute-path [filename]
-  (->> (str/split filename (re-pattern File/separator))
+  (->> (str/split filename (re-pattern (Pattern/quote File/separator)))
        (apply io/file)
        .getCanonicalPath))
 

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -19,9 +19,9 @@
     (apply println args)))
 
 (defn- relative-path [dir file]
-  (-> (.toURI dir)
-      (.relativize (.toURI file))
-      (.getPath)))
+  (-> (.toAbsolutePath (.toPath dir))
+      (.relativize (.toAbsolutePath (.toPath file)))
+      (.toString)))
 
 (defn- grep [re dir]
   (filter #(re-find re (relative-path dir %)) (file-seq (io/file dir))))


### PR DESCRIPTION
When running `lein cljfmt check` on Windows, regex exceptions occur.  For example:
```
java.util.regex.PatternSyntaxException: Unexpected internal error near index 1
\
 ^
 at java.util.regex.Pattern.error (:-1)
    java.util.regex.Pattern.compile (:-1)
    java.util.regex.Pattern.<init> (:-1)
    java.util.regex.Pattern.compile (:-1)
    clojure.core$re_pattern.invokeStatic (core.clj:4665)
    clojure.core$re_pattern.invoke (core.clj:4657)
    cljfmt.diff$to_absolute_path.invokeStatic (diff.clj:14)
```

This is caused by the use of `File/separator` in Windows environments.  
https://github.com/weavejester/cljfmt/blob/624ab9649818b11ad9806590a2ed0ba181c5b2a6/cljfmt/src/cljfmt/diff.clj#L13-L16

Despite the path being retrieved from a `URI` object
https://github.com/weavejester/cljfmt/blob/624ab9649818b11ad9806590a2ed0ba181c5b2a6/cljfmt/src/cljfmt/main.clj#L21-L24

On Windows, file paths separate on `\` but URLs _always_ use `/` - https://docs.oracle.com/javase/7/docs/api/java/net/URI.html?is-external=true

Therefore `/` can be used freely so that `lein cljfmt check` can execute successfully on Windows as well as Unix environments.