### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ selectively enabled or disabled:
 You can also configure the behavior of cljfmt:
 
 * `:file-pattern` -
-  determines which files to scan, `#”\.clj[sx]?$”` by default.
+  determines which files to scan, `#”\.clj[csx]?$”` by default.
 
 * `:indents` -
   a map of var symbols to indentation rules, i.e. `{symbol [& rules]}`.


### PR DESCRIPTION
Small inconsistency with the code: `:file-pattern` includes cljc files by default too