### PR TITLE
Indent clojure.spec.alpha/fdef like clojure.core/def

### DIFF
--- a/cljfmt/resources/cljfmt/indents/clojure.clj
+++ b/cljfmt/resources/cljfmt/indents/clojure.clj
@@ -30,6 +30,7 @@
  extend          [[:block 1]]
  extend-protocol [[:block 1] [:inner 1]]
  extend-type     [[:block 1] [:inner 1]]
+ fdef            [[:inner 0]]
  finally         [[:block 0]]
  fn              [[:inner 0]]
  for             [[:block 1]]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -35,7 +35,17 @@
     (is (= (reformat-string "(fn [x]\n(foo bar\nbaz))")
            "(fn [x]\n  (foo bar\n       baz))"))
     (is (= (reformat-string "(fn [x] (foo bar\nbaz))")
-           "(fn [x] (foo bar\n             baz))")))
+           "(fn [x] (foo bar\n             baz))"))
+    (is (= (reformat-string (str "(clojure.spec.alpha/def ::foo\n"
+                                 "                        string?)" ))
+           "(clojure.spec.alpha/def ::foo\n  string?)"))
+    (is (= (reformat-string
+            (str "(clojure.spec.alpha/fdef foo\n"
+                 "                         :args (clojure.spec.alpha/cat :x string?)\n"
+                 "                         :ret nat-int?)"))
+           (str "(clojure.spec.alpha/fdef foo\n"
+                "  :args (clojure.spec.alpha/cat :x string?)\n"
+                "  :ret nat-int?)"))))
 
   (testing "inner indentation"
     (is (= (reformat-string "(letfn [(foo [x]\n(* x x))]\n(foo 5))")


### PR DESCRIPTION
Clojure Spec's `fdef` is currently indented by cljfmt like any other form:

```
(s/fdef update-balance
        :args (s/cat :entry :ccm.transaction/entry
                     :balance :ccm.account/balance)
        :ret :ccm.account/balance
        :fn #(= (-> % :ret :ccm.money/currency)
                (-> % :args second :ccm.money/currency)))
```

However, both the [Clojure spec guide](https://clojure.org/guides/spec#_spec_ing_functions) and [Emacs clojure-mode](https://github.com/clojure-emacs/clojure-mode/blob/master/CHANGELOG.md#580-2018-06-26) indent it like a `clojure.core/def`.

This pull request brings cljfmt in-line with the `def`-style formatting and indents like this:

```
(s/fdef ranged-rand
  :args (s/and (s/cat :start int? :end int?)
               #(< (:start %) (:end %)))
  :ret int?
  :fn (s/and #(>= (:ret %) (-> % :args :start))
             #(< (:ret %) (-> % :args :end))))
```

Note that as a workaround you can currently specify a rule for `fdef` in your `project.clj` (if using `lein-cljfmt`). This is what we do internally:

```
:cljfmt {:indents {fdef [[:inner 0]]}}
```