### PR TITLE
add deps.edn file

### DIFF
--- a/cljfmt/deps.edn
+++ b/cljfmt/deps.edn
@@ -1,0 +1,15 @@
+{:deps
+ {org.clojure/clojure {:mvn/version "1.8.0"}
+  org.clojure/tools.cli {:mvn/version "0.3.7"}
+  org.clojure/tools.reader {:mvn/version "1.2.2"}
+  com.googlecode.java-diff-utils/diffutils {:mvn/version "1.3.0"}
+  rewrite-clj {:mvn/version "0.6.0"}
+  rewrite-cljs {:mvn/version "0.4.4"}}
+
+ :paths ["src" "resources"]
+
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                                          :sha "3cb0a9daf1cb746259dc8309b218f9211ad3b33b"}
+                               org.clojure/clojure {:mvn/version "1.9.0"}}
+                  :main-opts ["-m" "cognitect.test-runner"]}}}


### PR DESCRIPTION
It's quite minimal but it works. 

It can be useful to test non-released versions among other thing since we can pull dependencies via git directly. 

I am not familiar with the cljs part of things, but I guess it shouldn't be too hard to add on top of that. 