### PR TITLE
Change linebreak handling to work with Windows (fixes #137)

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -2,6 +2,7 @@
   #?@(:clj
       [(:refer-clojure :exclude [reader-conditional?])
        (:require [clojure.java.io :as io]
+                 [clojure.string :as str]
                  [clojure.zip :as zip]
                  [rewrite-clj.node :as n]
                  [rewrite-clj.parser :as p]
@@ -390,3 +391,20 @@
          (reformat-form (cond-> options
                           alias-map (assoc :alias-map alias-map)))
          (n/string)))))
+
+(def default-line-separator
+  #?(:clj (System/lineSeparator) :cljs \newline))
+
+(defn normalize-newlines [s]
+  (str/replace s #"\r\n" "\n"))
+
+(defn replace-newlines [s sep]
+  (str/replace s #"\n" sep))
+
+(defn find-line-separator [s]
+  (or (re-find #"\r?\n" s) default-line-separator))
+
+(defn wrap-normalize-newlines [f]
+  (fn [s]
+    (let [sep (find-line-separator s)]
+      (-> s normalize-newlines f (replace-newlines sep)))))

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -34,7 +34,7 @@
       [f])))
 
 (defn- reformat-string [options s]
-  (cljfmt/reformat-string s options))
+  ((cljfmt/wrap-normalize-newlines #(cljfmt/reformat-string % options)) s))
 
 (defn- project-path [{:keys [project-root]} file]
   (-> project-root (or ".") io/file (relative-path (io/file file))))


### PR DESCRIPTION
Linebreaks normalised to *nix '\n' (LF) for comparison.

Linebreak in re-written file will be same as linebreak in original file.
If no linebreak in original file, linebreak in rewritten will be OS default.

short vid showing it running on Win OS and handling both `LF` `(\n)` and `CR``LF` `(\n)` linebreaks: https://www.youtube.com/watch?v=OWpzFekl49U 