### PR TITLE
Check for not command-next at indent to fix remove-surrounding-whites…

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -123,11 +123,8 @@
 (defn- comment-next? [zloc]
   (-> zloc zip/next skip-whitespace comment?))
 
-(defn- line-break-next? [zloc]
-  (-> zloc zip/next skip-whitespace line-break?))
-
 (defn- should-indent? [zloc]
-  (and (line-break? zloc) (not (line-break-next? zloc))))
+  (and (line-break? zloc) (not (comment-next? zloc))))
 
 (defn- should-unindent? [zloc]
   (and (indentation? zloc) (not (comment-next? zloc))))

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -256,7 +256,9 @@
            "( foo bar )\n"))
     (is (= (reformat-string
             "( foo bar )   \n( foo baz )\n" {:remove-surrounding-whitespace? false})
-           "( foo bar )\n( foo baz )\n"))))
+           "( foo bar )\n( foo baz )\n"))
+    (is (= (reformat-string "(foo\n(bar\n)\n)" {:remove-surrounding-whitespace? false})
+           "(foo\n (bar\n  )\n )"))))
 
 (deftest test-options
   (is (= (reformat-string "(foo)\n\n\n(bar)" {:remove-consecutive-blank-lines? false})


### PR DESCRIPTION
…pace? set to false

Tries to fix #141.

I'm still puzzled about the function `line-break-next?` though, @weavejester, is there some test I could add that invalidates this PR?