### PR TITLE
Make string-format unit tests more readable

### DIFF
--- a/cljfmt/test/cljfmt/test_util/cljs.cljc
+++ b/cljfmt/test/cljfmt/test_util/cljs.cljc
@@ -1,0 +1,7 @@
+(ns cljfmt.test-util.cljs
+  (:require [cljs.test :as test]
+            [cljfmt.test-util.common :as common]))
+
+#?(:clj
+   (defmethod test/assert-expr 'reformats-to? [_env msg form]
+     `(test/do-report (common/assert-reformats-to ~msg ~@(rest form)))))

--- a/cljfmt/test/cljfmt/test_util/clojure.clj
+++ b/cljfmt/test/cljfmt/test_util/clojure.clj
@@ -1,0 +1,6 @@
+(ns cljfmt.test-util.clojure
+  (:require [clojure.test :as test]
+            [cljfmt.test-util.common :as common]))
+
+(defmethod test/assert-expr 'reformats-to? [msg form]
+  `(test/do-report (common/assert-reformats-to ~msg ~@(rest form))))

--- a/cljfmt/test/cljfmt/test_util/common.cljc
+++ b/cljfmt/test/cljfmt/test_util/common.cljc
@@ -1,0 +1,15 @@
+(ns cljfmt.test-util.common
+  (:require [clojure.string :as str]
+            [cljfmt.core :refer [reformat-string]]))
+
+(defn assert-reformats-to
+  ([msg in-lines expected-lines]
+   (assert-reformats-to msg in-lines expected-lines {}))
+  ([msg in-lines expected-lines options]
+   (let [input        (str/join "\n" in-lines)
+         actual       (reformat-string input options)
+         actual-lines (str/split actual #"\n" -1)]
+     {:type (if (= expected-lines actual-lines) :pass :fail)
+      :message  msg
+      :expected expected-lines
+      :actual   actual-lines})))


### PR DESCRIPTION
Rework string-format unit tests to be easier to digest by:

 - Giving each input line its own line (no more embbeded \n)

 - Making the intent of each test clear by giving it a description

 - Making failures easier to decipher by switching expected and actual

Fixes #145.