### PR TITLE
Fix inner indentation with index

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -211,7 +211,7 @@
 
 (defn- index-matches-top-argument? [zloc depth idx]
   (and (> depth 0)
-       (= idx (index-of (nth (iterate z/up zloc) (dec depth))))))
+       (= (inc idx) (index-of (nth (iterate z/up zloc) depth)))))
 
 (defn- fully-qualify-symbol [possible-sym alias-map]
   (if-let [ns-string (and (symbol? possible-sym)

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -132,6 +132,16 @@
           "          (* x x))]"
           "  (foo 5))"]))
     (is (reformats-to?
+         ["(letfn [(foo [x]"
+          "(* x x))"
+          "(bar [x]\n(+ x x))]"
+          "(foo 5))"]
+         ["(letfn [(foo [x]"
+          "          (* x x))"
+          "        (bar [x]"
+          "          (+ x x))]"
+          "  (foo 5))"]))
+    (is (reformats-to?
          ["(reify Closeable"
           "(close [_]"
           "(prn :closed)))"]


### PR DESCRIPTION
`idx` -> `(inc idx)`

According to the README, the index specified for inner indentation is
the index of the argument.

For example, specifying an index of 0 means that the inner indentation
is targeting the first argument. However, the first argument does not
have an index of 0 within the form. It has an index of 1, because the
first argument should be the second expression in the current list.

`(dec depth)` -> `depth`

Considering that `(first (iterate z/up zloc))` is `zloc` itself, it is
not necessary to decrement `depth`.

Fixes #73.