### PR TITLE
Indentation is correct after comment

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -337,7 +337,38 @@
           "x)"]
          ["(binding [x 1] ; foo"
           "  x)"])
-        "binding inline comment unchanged, code indented"))
+        "binding inline comment unchanged, code indented")
+    (is (reformats-to?
+         ["(let [x y]"
+          "  [this"
+          "   that"
+          "   ;;other"
+          "   ]"
+          "  )"]
+         ["(let [x y]"
+          "  [this"
+          "   that"
+          "   ;;other"
+          "   ])"])
+        "indents correctly after last comment in block")
+    (is (reformats-to?
+         ["(defn foo"
+          "  []"
+          "  (let [x 1]"
+          "    x"
+          "    ;; test1"
+          "    )"
+          "  ;; test2"
+          "  )"]
+         ["(defn foo"
+          "  []"
+          "  (let [x 1]"
+          "    x"
+          "    ;; test1"
+          "    )"
+          "  ;; test2"
+          "  )"])
+        "indentation should not be lost after comment line"))
 
   (testing "metadata"
     (is (reformats-to?


### PR DESCRIPTION
Added tests to verify this is no longer an issue.

Thanks to @jcf for pull request #88, I manually merged your test into this commit which means #88 can now be discarded.

Closes #82.