### PR TITLE
Fix indent for [[:block 0]] forms when the close paren is on a new line

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -247,7 +247,7 @@
   (if (or (indent-matches? key (fully-qualify-symbol (form-symbol zloc) alias-map))
           (indent-matches? key (remove-namespace (form-symbol zloc))))
     (if (and (or
-              (codeless-block? zloc)
+              (and (codeless-block? zloc) (not= idx 0))
               (some-> zloc (nth-form (inc idx)) first-form-in-line?))
              (> (index-of zloc) idx))
       (inner-indent zloc key 0 nil alias-map)

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -63,7 +63,7 @@
          ["(cond->> x"
           "  a? a"
           "  b? b)"])))
-
+  
   (testing "constant indentation"
     (is (reformats-to?
          ["(def foo"
@@ -461,6 +461,18 @@
           "    (let [a b]"
           "      ;; comment only"
           "      )))"]))
+    (is (reformats-to?
+         ["(cond foo"
+          "  )"]
+         ["(cond foo"
+          "      )"]
+         {:remove-surrounding-whitespace? false}))
+    (is (reformats-to?
+         ["(cond foo"
+          "bar)"]
+         ["(cond foo"
+          "      bar)"]
+         {:remove-surrounding-whitespace? false}))
     (is (reformats-to?
          ["(let []"
           ")"]


### PR DESCRIPTION
Special cases [[:block 0]] forms, so that #156 doesn't interfere with their formatting.