### PR TITLE
Documents usage with deps.tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,34 @@ As with the `check` task, you can choose to fix a specific file:
 
     lein cljfmt fix src/foo/core.clj
 
+### deps.tools usage
+
+It is possible to execute `cljfmt` using the
+[Clojure CLI], without integrating with `lein`.
+
+[Clojure CLI]: https://clojure.org/guides/deps_and_cli
+
+```bash
+clojure -Sdeps '{:deps {cljfmt {:mvn/version "0.6.4"}}}' \
+  -m cljfmt.main [check|fix]
+```
+
+Customizing the rules is possible passing `edn` formated files,
+using the same content used on lein profiles.
+
+As example, with the following content to the `indentation.edn`
+file, it is possible to customize the rules.
+
+```clojure
+{org.me/foo [[:inner 0]]}
+```
+
+```bash
+clojure -Sdeps '{:deps {cljfmt {:mvn/version "0.6.4"}}}' \
+  -m cljfmt.main check \
+  --indents indentation.edn
+```
+
 ## Editor Support
 
 * [vim-cljfmt](https://github.com/venantius/vim-cljfmt)


### PR DESCRIPTION
Since #123 it is now possible to use `cljfmt` without integrating it with lein.
This is very useful for CI scripts, where you might want to check for indentation, but would rather not download all the projects dependencies.

This commit documents the usage with `deps-tools`, using the `clojure` command line to execute `cljfmt` without using the pluging interface. It includes how to configure the tool without using the lein profile setup.

Closes #93