### PR TITLE
Fix for "Qualifed indent specs are not applied in the referred namespace itself"

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -241,6 +241,20 @@
           #?@(:cljs [:alias-map {"t" "thing.core"}])})
         "applies custom indentation to namespaced defn")
     (is (reformats-to?
+         ["(comment)"
+          "(ns thing.core)"
+          ""
+          "(defthing foo [x]"
+          "(+ x 1))"]
+         ["(comment)"
+          "(ns thing.core)"
+          ""
+          "(defthing foo [x]"
+          "  (+ x 1))"]
+         {:indents {'thing.core/defthing [[:inner 0]]}
+          #?@(:cljs [:alias-map {}])})
+        "recognises the current namespace as part of a qualifed indent spec")
+    (is (reformats-to?
          ["(ns example"
           "(:require [thing.core :as t]))"
           ""


### PR DESCRIPTION
Fixes #166.

---

Old version (i.e. first commit):

Merely a (working) POC with some acknowledged defects:

* Uses `clojure.tools.namespace` for ns parsing, I guess a rewrite-clj implementation is a must for cljs compat.
* A dynamic var is introduced. I recall you don't favor them. OTOH `defn- inner-indent [zloc key depth idx alias-map]` (and several other defns) would get another argument, which might become unwieldy.