### PR TITLE
Add support for namespaced maps

### DIFF
--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -8,7 +8,7 @@
                  [org.clojure/tools.cli "0.3.7"]
                  [org.clojure/tools.reader "1.2.2"]
                  [com.googlecode.java-diff-utils/diffutils "1.3.0"]
-                 [rewrite-clj "0.6.0"]
+                 [rewrite-clj "0.6.1"]
                  [rewrite-cljs "0.4.4"]]
   :plugins [[lein-cljsbuild "1.1.7"]]
   :hooks [leiningen.cljsbuild]

--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -77,9 +77,13 @@
 (defn- reader-macro? [zloc]
   (and zloc (= (n/tag (z/node zloc)) :reader-macro)))
 
+(defn- namespaced-map? [zloc]
+  (and zloc (= (n/tag (z/node zloc)) :namespaced-map)))
+
 (defn- missing-whitespace? [zloc]
   (and (element? zloc)
        (not (reader-macro? (zip/up zloc)))
+       (not (namespaced-map? (zip/up zloc)))
        (element? (zip/right zloc))))
 
 (defn insert-missing-whitespace [form]
@@ -146,7 +150,8 @@
   {:meta "^", :meta* "#^", :vector "[",       :map "{"
    :list "(", :eval "#=",  :uneval "#_",      :fn "#("
    :set "#{", :deref "@",  :reader-macro "#", :unquote "~"
-   :var "#'", :quote "'",  :syntax-quote "`", :unquote-splicing "~@"})
+   :var "#'", :quote "'",  :syntax-quote "`", :unquote-splicing "~@"
+   :namespaced-map "#"})
 
 (defn- prior-line-string [zloc]
   (loop [zloc     zloc

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -609,7 +609,14 @@
           ":cljs bar)"]
          ["#?@(:clj foo"
           "    :cljs bar)"])
-        "splicing syntax")))
+        "splicing syntax"))
+
+  (testing "namespaced maps"
+    (is (reformats-to?
+         ["#:clj {:a :b"
+          ":c :d}"]
+         ["#:clj {:a :b"
+          "       :c :d}"]))))
 
 (deftest test-surrounding-whitespace
   (testing "surrounding whitespace removed"


### PR DESCRIPTION
rewrite-clj 0.6.1 [introduced namespaced-map](https://github.com/xsc/rewrite-clj/pull/66) support.

This changed the tag of the form and broke formatting for this reader macro.