### PR TITLE
Native image

### DIFF
--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -10,7 +10,8 @@
                  [com.googlecode.java-diff-utils/diffutils "1.3.0"]
                  [rewrite-clj "0.6.1"]
                  [rewrite-cljs "0.4.4"]]
-  :plugins [[lein-cljsbuild "1.1.7"]]
+  :plugins [[lein-cljsbuild "1.1.7"]
+            [io.taylorwood/lein-native-image "0.3.1"]]
   :hooks [leiningen.cljsbuild]
   :cljsbuild {:builds
               {"dev" {:source-paths ["src" "test"]
@@ -21,5 +22,24 @@
                                  :optimizations :none}}}
               :test-commands
               {"dev" ["node" "target/out/tests.js"]}}
+  :native-image
+  {:name "cljfmt"
+   :opts ["--verbose"
+          "-H:+ReportExceptionStackTraces"
+          "-J-Dclojure.spec.skip-macros=true"
+          "-J-Dclojure.compiler.direct-linking=true"
+          "-H:ReflectionConfigurationFiles=reflection.json"
+          "--initialize-at-build-time"
+          "-H:Log=registerResource:"
+          "--verbose"
+          "--no-fallback"
+          "--no-server"
+          "-J-Xmx3g"]}
   :profiles
-  {:provided {:dependencies [[org.clojure/clojurescript "1.10.520"]]}})
+  {:uberjar
+   {:main cljfmt.main
+    :aot :all
+    :native-image
+    {:jvm-opts ["-Dclojure.compiler.direct-linking=true"
+                "-Dclojure.spec.skip-macros=true"]}}
+   :provided {:dependencies [[org.clojure/clojurescript "1.10.520"]]}})

--- a/cljfmt/reflection.json
+++ b/cljfmt/reflection.json
@@ -1,0 +1,9 @@
+[
+    {
+        "name": "java.lang.Class",
+        "allDeclaredConstructors": true,
+        "allPublicConstructors": true,
+        "allDeclaredMethods": true,
+        "allPublicMethods": true
+    }
+]

--- a/cljfmt/src/cljfmt/diff.clj
+++ b/cljfmt/src/cljfmt/diff.clj
@@ -13,7 +13,7 @@
 
 (defn to-absolute-path [filename]
   (->> (str/split filename (re-pattern (Pattern/quote File/separator)))
-       (apply io/file)
+       ^java.io.File (apply io/file)
        .getCanonicalPath))
 
 (defn unified-diff

--- a/cljfmt/src/cljfmt/impl/stacktrace.clj
+++ b/cljfmt/src/cljfmt/impl/stacktrace.clj
@@ -1,0 +1,61 @@
+;;;   Copyright (c) Rich Hickey. All rights reserved.
+;;;   The use and distribution terms for this software are covered by the
+;;;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;;   which can be found in the file epl-v10.html at the root of this distribution.
+;;;   By using this software in any fashion, you are agreeing to be bound by
+;;;   the terms of this license.
+;;;   You must not remove this notice, or any other, from this software.
+
+;;; stacktrace.clj: print Clojure-centric stack traces
+
+;; by Stuart Sierra
+;; January 6, 2009
+
+(ns cljfmt.impl.stacktrace)
+
+;;; Bring over the functions from stacktrace because they need to be
+;;; type hinted for the native-image to work
+
+(defn print-trace-element
+  "Prints a Clojure-oriented view of one element in a stack trace."
+  {:added "1.1"}
+  [^java.lang.StackTraceElement e]
+  (let [class (.getClassName e)
+        method (.getMethodName e)
+        match (re-matches #"^([A-Za-z0-9_.-]+)\$(\w+)__\d+$" (str class))]
+    (if (and match (= "invoke" method))
+      (apply printf "%s/%s" (rest match))
+      (printf "%s.%s" class method)))
+  (printf " (%s:%d)" (or (.getFileName e) "") (.getLineNumber e)))
+
+(defn print-throwable
+  "Prints the class and message of a Throwable. Prints the ex-data map
+  if present."
+  {:added "1.1"}
+  [^Throwable tr]
+  (printf "%s: %s" (.getName (class tr)) (.getMessage tr))
+  (when-let [info (ex-data tr)]
+    (newline)
+    (pr info)))
+
+(defn print-stack-trace
+  "Prints a Clojure-oriented stack trace of tr, a Throwable.
+  Prints a maximum of n stack frames (default: unlimited).
+  Does not print chained exceptions (causes)."
+  {:added "1.1"}
+  ([tr] (print-stack-trace tr nil))
+  ([^Throwable tr n]
+   (let [st (.getStackTrace tr)]
+     (print-throwable tr)
+     (newline)
+     (print " at ")
+     (if-let [e (first st)]
+       (print-trace-element e)
+       (print "[empty stack trace]"))
+     (newline)
+     (doseq [e (if (nil? n)
+                 (rest st)
+                 (take (dec n) (rest st)))]
+       (print "    ")
+       (print-trace-element e)
+       (newline)))))

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -3,10 +3,10 @@
   (:require [cljfmt.core :as cljfmt]
             [clojure.edn :as edn]
             [clojure.java.io :as io]
-            [clojure.string :as str]
-            [clojure.stacktrace :as st]
+            [cljfmt.impl.stacktrace :as st]
             [clojure.tools.cli :as cli]
-            [cljfmt.diff :as diff]))
+            [cljfmt.diff :as diff])
+  (:gen-class))
 
 (defn- abort [& msg]
   (binding [*out* *err*]
@@ -18,7 +18,7 @@
   (binding [*out* *err*]
     (apply println args)))
 
-(defn- relative-path [dir file]
+(defn- relative-path [^java.io.File dir ^java.io.File file]
   (-> (.toAbsolutePath (.toPath dir))
       (.relativize (.toAbsolutePath (.toPath file)))
       (.toString)))


### PR DESCRIPTION
Hello,

I found myself needing to build a native-image from cljfmt for my poor coworkers, so while I hacked together some side repo to help them, I thought I'd open a bit more detailed PR to facilitate it in the project itself.

Contents of this PR:
- Adds type hints to functions which broke under native-image reflection.
- Pulls in functions from `stacktrace` to add type hints to them when needed for the same reason.
- Adds stub lein app to generate a native-image from, with a compile script for GraalVM.

Please let me know if there are any issues with it or if I made some mess of the licensing

Cheers,
Ben