### PR TITLE
feature(ignore-shebangs): ignores shebangs for babashka support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ selectively enabled or disabled:
   true if cljfmt should collapse consecutive blank lines. This will
   convert `(foo)\n\n\n(bar)` to `(foo)\n\n(bar)`. Defaults to true.
 
+* `ignore-shebangs?` -
+  true if cljfmt should ignore `#!` lines. Great for (https://github.com/borkdude/babashkababashka)[babashka]
 
 You can also configure the behavior of cljfmt:
 

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -148,6 +148,7 @@
    :remove-surrounding-whitespace?  true
    :remove-trailing-whitespace?     true
    :remove-consecutive-blank-lines? true
+   :ignore-shebangs?                true
    :indents   cljfmt/default-indents
    :alias-map {}})
 
@@ -186,7 +187,10 @@
     :id :insert-missing-whitespace?]
    [nil "--[no-]remove-consecutive-blank-lines"
     :default (:remove-consecutive-blank-lines? default-options)
-    :id :remove-consecutive-blank-lines?]])
+    :id :remove-consecutive-blank-lines?]
+   [nil "--[no-]ignore-shebangs"
+    :default (:ignore-shebangs? default-options)
+    :id :ignore-shebanks?]])
 
 (defn- command-name []
   (or (System/getProperty "sun.java.command") "cljfmt"))

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -926,7 +926,15 @@
         " bar "
         " )"]
        {:remove-surrounding-whitespace? false
-        :remove-trailing-whitespace? false})))
+        :remove-trailing-whitespace? false}))
+  (is (reformats-to?
+       ["#!/usr/bin/env bb"]
+       ["#!/usr/bin/env bb"]
+       {:ignore-shebang? true}))
+  (is (reformats-to?
+       ["#!/usr/bin/env bash"]
+       ["#!/usr/bin/env bash"]
+       {:ignore-shebang? true})))
 
 (deftest test-parsing
   (is (reformats-to?


### PR DESCRIPTION
Closes #178. Needed it because I've been writing clj scripts.