### PR TITLE
Reduce the z/sexpr cost in find-namespace

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -209,20 +209,24 @@
        (take-while (complement root?))
        last))
 
+(defn- token? [zloc]
+  (= (z/tag zloc) :token))
+
+(defn- ns-token? [zloc]
+  (and (token? zloc)
+       (= 'ns (z/sexpr zloc))))
+
 (defn- ns-form? [zloc]
-  (some-> zloc child-sexprs first (= 'ns)))
+  (some-> zloc z/down ns-token?))
 
 (defn- find-namespace [zloc]
-  (some-> zloc top (z/find z/next ns-form?) z/sexpr second))
+  (some-> zloc top (z/find z/next ns-form?) z/down z/next z/sexpr))
 
 (defn- indent-matches? [key sym]
   (if (symbol? sym)
     (cond
       (symbol? key)  (= key sym)
       (pattern? key) (re-find key (str sym)))))
-
-(defn- token? [zloc]
-  (= (z/tag zloc) :token))
 
 (defn- token-value [zloc]
   (if (token? zloc) (z/sexpr zloc)))


### PR DESCRIPTION
This patch addresses the slowdown introduced between 0.6.4 and 0.6.5
and fixes #181.

Prior to this patch, find-namespace and ns-form? called z/sexpr on
all traversed forms. The find-namespace logic needed only parts of
resulting sexprs.

The cost of z/sexpr was non-negligible when invoked on complex forms.
As a result, z/sexpr and nested functions dominated the CPU cost of
the indentation logic.

This patch makes z/sexpr calls more fine-granular and avoids invoking
the function on nodes irrelevant to find-namespace. This results in a
tenfold speedup.

Changes to ns-form? and find-namespace contribute equally to the speed
improvement. Consider the following test case.

    (let [in (slurp "src/cljfmt/core.cljc")]
      (criterium/quick-bench (cljfmt.core/reformat-string in)))

The impact of individual hunks looks as follows.

    Benchmarked code                 Mean time [s]
    ----------------------------------------------
    Status quo                                 4.4
    with the ns-form? hunk                     1.7
    and with the find-namespace hunk           0.4