### PR TITLE
Lint project.clj and/or deps.edn if they exist

### DIFF
--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -191,11 +191,14 @@
 (defn- command-name []
   (or (System/getProperty "sun.java.command") "cljfmt"))
 
+(defn- file-exists? [path]
+  (.exists (io/as-file path)))
+
 (defn -main [& args]
   (let [parsed-opts   (cli/parse-opts args cli-options)
         [cmd & paths] (:arguments parsed-opts)
         options       (merge-default-options (:options parsed-opts))
-        paths         (or (seq paths) default-paths)]
+        paths         (or (seq paths) (filter file-exists? default-paths))]
     (if (:errors parsed-opts)
       (abort (:errors parsed-opts))
       (if (or (nil? cmd) (:help options))


### PR DESCRIPTION
The default paths should include deps.edn, for symmetry with #150. This
commit adds an existence check for all default paths, to avoid failing
on a missing default path. The current set should cover these common
project types:

- Leiningen projects with `project.clj` present
- tools.deps projects with `deps.edn` present
- Combinations where both are present, eg. lein projects using the
  lein-tools-deps plugin.

Resolves #192.