### PR TITLE
Add split-maps? option, break hashmaps into lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ selectively enabled or disabled:
   true if cljfmt should collapse consecutive blank lines. This will
   convert `(foo)\n\n\n(bar)` to `(foo)\n\n(bar)`. Defaults to true.
 
+* `:split-keypairs-over-multiple-lines?` -
+  true if cljfmt should break hashmaps onto multiple lines. This will
+  convert `{:a 1 :b 2}` to `{:a 1\n:b 2}`. Defaults to false.
 
 You can also configure the behavior of cljfmt:
 

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -926,7 +926,59 @@
         " bar "
         " )"]
        {:remove-surrounding-whitespace? false
-        :remove-trailing-whitespace? false})))
+        :remove-trailing-whitespace? false}))
+  (is (reformats-to?
+       ["{:one two :three four}"]
+       ["{:one two"
+        " :three four}"]
+       {:split-keypairs-over-multiple-lines? true}))
+  (is (reformats-to?
+       ["{:one two"
+        " :three four}"]
+       ["{:one two"
+        " :three four}"]
+       {:split-keypairs-over-multiple-lines? true}))
+  (is (reformats-to?
+       ["{:one two"
+        ";comment"
+        ":three four}"]
+       ["{:one two"
+        ";comment"
+        " :three four}"]
+       {:split-keypairs-over-multiple-lines? true}))
+  (is (reformats-to?
+       ["{:one two ;comment"
+        ":three four}"]
+       ["{:one two ;comment"
+        " :three four}"]
+       {:split-keypairs-over-multiple-lines? true}))
+  (is (reformats-to?
+       ["{;comment"
+        ":one two"
+        ":three four}"]
+       ["{;comment"
+        " :one two"
+        " :three four}"]
+       {:split-keypairs-over-multiple-lines? true}))
+  (is (reformats-to?
+       ["{:one two, :three four}"]
+       ["{:one two, "
+        " :three four}"]
+       {:split-keypairs-over-multiple-lines? true
+        :remove-trailing-whitespace? false}))
+  (is (reformats-to?
+       ["{:one two,"
+        " :three four}"]
+       ["{:one two,"
+        " :three four}"]
+       {:split-keypairs-over-multiple-lines? true
+        :remove-trailing-whitespace? false}))
+  (is (reformats-to?
+       ["{:one two #_comment"
+        ":three four}"]
+       ["{:one two #_comment"
+        " :three four}"]
+       {:split-keypairs-over-multiple-lines? true})))
 
 (deftest test-parsing
   (is (reformats-to?


### PR DESCRIPTION
The clojure style guide includes several valid hashmap structures,
inline, comma separated, and newline separated. This adds explicit
support for newline separated hashmaps, so that they can be
uniformly applied across a project.
