### PR TITLE
Adding :more-newlines? option

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -430,7 +430,15 @@
 (defn find-line-separator [s]
   (or (re-find #"\r?\n" s) default-line-separator))
 
-(defn wrap-normalize-newlines [f]
-  (fn [s]
-    (let [sep (find-line-separator s)]
-      (-> s normalize-newlines f (replace-newlines sep)))))
+(defn add-more-newlines [s]
+  (str/replace s #"\n{2}" "\n\n\n"))
+
+(defn wrap-normalize-newlines
+  ([f]
+   (wrap-normalize-newlines f {}))
+  ([f options]
+   (fn [s]
+     (let [sep (find-line-separator s)
+           s   (-> s normalize-newlines f (replace-newlines sep))]
+       (cond-> s
+               (:more-newlines? options) add-more-newlines)))))

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -34,7 +34,7 @@
       [f])))
 
 (defn- reformat-string [options s]
-  ((cljfmt/wrap-normalize-newlines #(cljfmt/reformat-string % options)) s))
+  ((cljfmt/wrap-normalize-newlines #(cljfmt/reformat-string % options) options) s))
 
 (defn- project-path [{:keys [project-root]} file]
   (-> project-root (or ".") io/file (relative-path (io/file file))))


### PR DESCRIPTION
Cljfmt's default behaviour is putting 2 newlines between forms (defns), it's good to have 3 newlines, makes it easy to read.