### PR TITLE
Add :remove-extra-whitespace? option

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -386,6 +386,15 @@
 (defn remove-trailing-whitespace [form]
   (transform form edit-all trailing-whitespace? zip/remove))
 
+(defn- replace-with-one-space [zloc]
+  (zip/replace zloc (whitespace 1)))
+
+(defn- non-indenting-whitespace? [zloc]
+  (and (whitespace? zloc) (not (indentation? zloc))))
+
+(defn remove-multiple-non-indenting-spaces [form]
+  (transform form edit-all non-indenting-whitespace? replace-with-one-space))
+
 (defn reformat-form
   ([form]
    (reformat-form form {}))
@@ -399,6 +408,8 @@
          remove-surrounding-whitespace)
        (cond-> (:insert-missing-whitespace? opts true)
          insert-missing-whitespace)
+       (cond-> (:remove-multiple-non-indenting-spaces? opts false)
+         remove-multiple-non-indenting-spaces)
        (cond-> (:indentation? opts true)
          (reindent (:indents opts default-indents)
                    (:alias-map opts {})))

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -144,10 +144,11 @@
    :file-pattern #"\.clj[csx]?$"
    :ansi?        true
    :indentation? true
-   :insert-missing-whitespace?      true
-   :remove-surrounding-whitespace?  true
-   :remove-trailing-whitespace?     true
-   :remove-consecutive-blank-lines? true
+   :insert-missing-whitespace?            true
+   :remove-multiple-non-indenting-spaces? false
+   :remove-surrounding-whitespace?        true
+   :remove-trailing-whitespace?           true
+   :remove-consecutive-blank-lines?       true
    :indents   cljfmt/default-indents
    :alias-map {}})
 
@@ -175,6 +176,9 @@
    [nil "--[no-]indentation"
     :default (:indentation? default-options)
     :id :indentation?]
+   [nil "--[no-]remove-multiple-non-indenting-spaces"
+    :default (:remove-multiple-non-indenting-spaces? default-options)
+    :id :remove-multiple-non-indenting-spaces?]
    [nil "--[no-]remove-surrounding-whitespace"
     :default (:remove-surrounding-whitespace? default-options)
     :id :remove-surrounding-whitespace?]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -627,6 +627,44 @@
          ["#:clj {:a :b"
           "       :c :d}"]))))
 
+(deftest test-remove-multiple-non-indenting-spaces
+  (let [opts {:remove-multiple-non-indenting-spaces? true}]
+    (is (reformats-to? ["[]"] ["[]"] opts))
+    (is (reformats-to? ["[   ]"] ["[]"] opts))
+    (is (reformats-to? ["{   }"] ["{}"] opts))
+    (is (reformats-to? ["#{ }"] ["#{}"] opts))
+    (is (reformats-to? ["[a     b]"] ["[a b]"]  opts))
+    (is (reformats-to? ["{a     b}"] ["{a b}"] opts))
+    (is (reformats-to? ["{a,     b}"] ["{a, b}"] opts))
+    (is (reformats-to? ["#{a     b}"] ["#{a b}"] opts))
+    (is (reformats-to? ["#{    }"] ["#{}"] opts))
+    (is (reformats-to? ["[a     b   c]"] ["[a b c]"] opts))
+    (is (reformats-to? ["#{a     b     }"] ["#{a b}"] opts))
+    (is (reformats-to? ["(do"
+                        ""
+                        "  something)"]
+                       ["(do"
+                        ""
+                        "  something)"]
+                       opts)
+        "non-comment newlines are respected")
+    (is (reformats-to? ["(cond truc"
+                        "      ;; foo"
+                        "      (bar? a    b) :baz)"]
+                       ["(cond truc"
+                        "      ;; foo"
+                        "      (bar? a b) :baz)"]
+                       opts)
+        "comments are respected")
+    (is (reformats-to? ["(cond truc"
+                        "             ;; foo"
+                        "   (bar? a    b) :baz)"]
+                       ["(cond truc"
+                        "             ;; foo"
+                        "   (bar? a b) :baz)"]
+                       (assoc opts :indentation? false))
+        "custom indentation is respected")))
+
 (deftest test-surrounding-whitespace
   (testing "surrounding whitespace removed"
     (is (reformats-to?


### PR DESCRIPTION
Hi James, 

This pr adds a `:remove-extra-whitespace?` (defaulting to false). 

This can be handy to turn a project that used justified form alignement into the classical form.

It will go through all whitespace nodes and replace the ones with more than 1 char with a single char whitespace node. 
I set the default to false has not to be too surprising since now cljfmt will deal both styles (justified or not) by not altering the result. It will leave comments untouched. 

One quirky thing is that it must/should be run with `:indentation? true` only, otherwise the source gets all "compressed", so there's an argument to make it an option for indentation? or maybe force indentation if that formatter is on, not sure about that one. 


```text
[a    b c] -> [a b c]
{:a    :b} -> {:a :b} 
```

