### PR TITLE
Address comments, commas when removing blank lines

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -754,6 +754,13 @@
         "(bar)"]))
   (is (reformats-to?
        ["(foo)"
+        ","
+        "(bar)"]
+       ["(foo)"
+        ","
+        "(bar)"]))
+  (is (reformats-to?
+       ["(foo)"
         ""
         ""
         " (bar)"]
@@ -795,6 +802,93 @@
        ["(foo)"
         ""
         ";bar"
+        ""
+        "(baz)"]))
+  (is (reformats-to?
+       ["(foo)"
+        ""
+        ""
+        ""
+        ";bar"
+        "(baz)"]
+       ["(foo)"
+        ""
+        ";bar"
+        "(baz)"]))
+  (is (reformats-to?
+       ["(foo)"
+        ""
+        ""
+        ""
+        ";bar"
+        ""
+        ""
+        ""
+        ""
+        "(baz)"]
+       ["(foo)"
+        ""
+        ";bar"
+        ""
+        "(baz)"]))
+  (is (reformats-to?
+       ["(foo)"
+        ""
+        ""
+        ""
+        ";bar"
+        ""
+        ""
+        ""
+        ""
+        ";moo"
+        ""
+        ""
+        ""
+        ""
+        "(baz)"
+        ]
+       ["(foo)"
+        ""
+        ";bar"
+        ""
+        ";moo"
+        ""
+        "(baz)"]))
+  (is (reformats-to?
+       [";foo"
+        ""
+        ""
+        ";bar"
+        ""
+        ""
+        ";moo"
+        ""
+        ""
+        ";baz"]
+       [";foo"
+        ""
+        ";bar"
+        ""
+        ";moo"
+        ""
+        ";baz"]))
+  (is (reformats-to?
+       ["(foo)"
+        ","
+        ","
+        ";bar"
+        ","
+        ""
+        ";moo"
+        ","
+        "   ,,,,,  "
+        "(baz)"]
+       ["(foo)"
+        ""
+        ";bar"
+        ""
+        ";moo"
         ""
         "(baz)"]))
   (is (reformats-to?


### PR DESCRIPTION
- Now finding and removing consecutive blank lines between comments.
- Commas are now recognized as part of blank lines and removed.

Fixes #209

Notes for reviewer:
- renamed `whitespace?` to `space?` to distinguish it more from other types of whitespace