### PR TITLE
Add report-unsupported-native-image-at-runtime flag

### DIFF
--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -29,6 +29,7 @@
           "-J-Dclojure.compiler.direct-linking=true"
           "-H:ReflectionConfigurationFiles=reflection.json"
           "--initialize-at-build-time"
+          "--report-unsupported-elements-at-runtime"
           "-H:Log=registerResource:"
           "--verbose"
           "--no-fallback"


### PR DESCRIPTION
read-string breaks native-image building due to an unsupported reachable
method. By delaying the reporting of this method to run-time, it turns
out the compiled native-image still works.

Closes #217.