### PR TITLE
Parse style/indent metadata [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ It is possible to execute `cljfmt` using the
 [Clojure CLI]: https://clojure.org/guides/deps_and_cli
 
 ```bash
-clojure -Sdeps '{:deps {cljfmt {:mvn/version "0.6.4"}}}' \
-  -m cljfmt.main [check|fix]
+clojure -Sdeps '{:deps {cljfmt/cljfmt {:mvn/version "0.7.0"}}}' \
+  -M -m cljfmt.main [check|fix]
 ```
 
 Customizing the rules is possible passing `edn` formated files,
@@ -219,7 +219,7 @@ Indentation types are:
 * `:inner` -
   two character indentation applied to form arguments at a depth
   relative to a form symbol
-  
+
 * `:block` -
   first argument aligned indentation applied to form arguments at form
   depth 0 for a symbol
@@ -234,9 +234,9 @@ Form depth is the nested depth of any element within the form.
 A contrived example will help to explain depth:
 
 ```clojure
-(foo 
+(foo
  bar
- (baz 
+ (baz
   (qux plugh)
   corge)
  (grault

--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -6,6 +6,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/tools.cli "1.0.194"]
+                 [org.clojure/tools.namespace "1.1.0"]
                  [org.clojure/tools.reader "1.3.3"]
                  [com.googlecode.java-diff-utils/diffutils "1.3.0"]
                  [rewrite-clj "1.0.605-alpha"]]

--- a/cljfmt/src/cljfmt/files.clj
+++ b/cljfmt/src/cljfmt/files.clj
@@ -1,0 +1,114 @@
+(ns cljfmt.files
+  (:require [cljfmt.core :as cljfmt]
+            [clojure.java.io :as io]
+            [clojure.tools.namespace.file :as tools.ns.file]
+            [clojure.tools.namespace.find :as tools.ns.find]
+            [clojure.tools.namespace.parse :as tools.ns.parse]))
+
+(defn- relative-path [^java.io.File dir ^java.io.File file]
+  (-> (.toAbsolutePath (.toPath dir))
+      (.relativize (.toAbsolutePath (.toPath file)))
+      (.toString)))
+
+(defn- files-in-directory [^java.io.File dir {:keys [file-pattern platform], :or {platform :clj}}]
+  (let [files (tools.ns.find/find-sources-in-dir dir (case (keyword platform)
+                                                       :clj  tools.ns.find/clj
+                                                       :cljs tools.ns.find/cljs))]
+    (cond->> files
+      file-pattern (filter #(re-find file-pattern (relative-path dir %))))))
+
+(defn- find-files [path {:keys [project-root], :as options}]
+  {:pre [(string? path)]}
+  (try
+    (let [file (io/file path)]
+      (when-not (.exists file)
+        (throw (ex-info (str "No such file: " (str file))
+                        {:path path})))
+      (for [file (if (.isDirectory file)
+                   (files-in-directory file options)
+                   [file])]
+        {:file             file
+         :project-filename (-> project-root (or ".") io/file (relative-path file))}))
+    (catch Throwable e
+      (throw (ex-info (str "Error finding files: " (ex-message e))
+                      {:path    path
+                       :options options}
+                      e)))))
+
+(defn- load-file-namespace [file]
+  {:pre [(instance? java.io.File file)]}
+  (let [ns-decl (tools.ns.file/read-file-ns-decl file)
+        ns-symb (tools.ns.parse/name-from-ns-decl ns-decl)]
+    (try
+      (require ns-symb)
+      (the-ns ns-symb)
+      (catch Throwable e
+        (throw (ex-info (format "Error loading namespace %s: %s" ns-symb (ex-message e))
+                        {:namespace ns-symb}
+                        e))))))
+
+(defn- with-loaded-namespace [{:keys [file], :as info}]
+  (try
+    (if-let [file-namespace (load-file-namespace file)]
+      (assoc info :namespace file-namespace)
+      info)
+    (catch Throwable e
+      (assoc info :load-error (ex-info (format "Error loading file %s: %s" (str file) (ex-message e))
+                                       (merge {} info)
+                                       e)))))
+
+(defn- style-indent-spec->cljfmt-spec [spec]
+  (cond
+    (number? spec)
+    [[:block spec]]
+
+    (= spec :defn)
+    [[:inner 0]]
+
+    :else
+    (binding [*out* *err*]
+      (println "Don't know how to convert" (pr-str spec) "to a cljfmt spec")
+      nil)))
+
+(defn- ns-indent-metadata-specs [a-namespace]
+  (into {} (for [[symb varr] (ns-interns a-namespace)
+                 :let        [spec (some-> (meta varr) :style/indent style-indent-spec->cljfmt-spec)]
+                 :when       spec]
+             [symb spec])))
+
+(defn- ns-indents
+  [a-namespace]
+  (not-empty
+   (into
+    (ns-indent-metadata-specs a-namespace)
+    (for [[ns-alias nmspace] (ns-aliases a-namespace)
+          [symb spec] (ns-indent-metadata-specs nmspace)]
+      [(symbol (name ns-alias #_(ns-name nmspace)) (name symb)) spec]))))
+
+(defn- with-ns-indents [{file-namespace :namespace, :as info}]
+  (cond-> info
+    file-namespace (assoc :ns-indents (ns-indents file-namespace))))
+
+(defn- reformat-string [options s]
+  ((cljfmt/wrap-normalize-newlines #(cljfmt/reformat-string % options)) s))
+
+(defn- with-sources [{:keys [file ns-indents], :as info} options]
+  (let [options (cond-> options
+                  ns-indents (update :indents (partial merge ns-indents)))]
+    (merge
+     info
+     (try
+       (let [original (slurp file)]
+         {:original original
+          :revised  (reformat-string options original)})
+       (catch Throwable e
+         {:error e})))))
+
+(defn reducible-files [paths options]
+  {:pre [(sequential? paths) (every? string? paths)]}
+  (eduction
+   (mapcat #(find-files % options))
+   (map with-loaded-namespace)
+   (map with-ns-indents)
+   (map #(with-sources % options))
+   paths))


### PR DESCRIPTION
Implements #49

@weavejester, let me know if this approach works for you and I can add some tests and documentation and figure out how to translate more complicated `:style/indent` specs.

The basic idea here is to load the namespace associated with a file when we go to reformat/check it and then look in all the vars defined in that namespace and in its `ns-aliases` namespaces for `:style/indent` metadata, then take the specs and merge them into the `indents` map that gets passed to `cljfmt.main/reformat-string`. If it can't load the namespace for one reason or another (e.g. because the files aren't on the classpath) it will just catch the exception and reformat the file the same way it did before this PR.

I didn't want to duplicate all this code between both the `check` and `fix` code paths so I abstracted out that stuff into a new `cljfmt.files` namespace. Both `check` and `fix` transduce a `cljfmt.files/reducible-files` Eduction that includes all the relevant info as well as some other stuff that previously had to be recalculated on the fly. So overall I think this simplifies the code in `cljfmt.main` a bit.

I also made some tweaks to `check` and `fix` so they don't call `System/exit` if they fail. Instead, they throw an Exception, which `-main` catches and prints, then exits with a nonzero status. I made this change to make development easier (I was testing stuff out in the REPL as I worked on this) and so `cljfmt` is useful interactively -- supporting calling `cljfmt/check` inside a running REPL in a larger project seems like a nice thing to support, similar to how I can run `clojure.test` tests or Eastwood programmatically.

I pushed a working `deps.edn` demo to https://github.com/camsaul/cljfmt that you can try with

```bash
clojure -Sdeps \
  '{:deps {camsaul/cljfmt {:git/url "https://github.com/camsaul/cljfmt", :sha "ec3884db9b0961c59fd74972c1ca4594f0ab477f"}}}' \
  -M -m cljfmt.main [check|fix]
```

One last note: I haven't coded up support for every single indentation spec variation supported by CIDER `:style/indent` yet. So far it supports numeric indent specs and `:defn`, but not more complicated stuff like `[1 :defn]` or the like -- I haven't really dug in to how to translate all the specs at this point. If it doesn't understand a spec, it currently just prints a warning and moves on.