### PR TITLE
Refactor test utilities

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -4,7 +4,6 @@
             [cljfmt.core :refer [reformat-string default-line-separator
                                  normalize-newlines find-line-separator
                                  replace-newlines wrap-normalize-newlines]]
-            [cljfmt.test-util.common :as common]
             #?(:clj [cljfmt.test-util.clojure]))
   #?(:cljs (:require-macros [cljfmt.test-util.cljs])))
 

--- a/cljfmt/test/cljfmt/test_runner.cljs
+++ b/cljfmt/test/cljfmt/test_runner.cljs
@@ -1,7 +1,7 @@
 (ns cljfmt.test-runner
   (:require [cljs.nodejs :as nodejs]
             [cljs.test :refer-macros [run-tests]]
-            [cljfmt.core-test :as ct]))
+            [cljfmt.core-test]))
 
 (nodejs/enable-util-print!)
 

--- a/cljfmt/test/cljfmt/test_util/cljs.clj
+++ b/cljfmt/test/cljfmt/test_util/cljs.clj
@@ -1,8 +1,8 @@
-(ns cljfmt.test-util.clojure
-  (:require [clojure.test :as test]
+(ns cljfmt.test-util.cljs
+  (:require [cljs.test :as test]
             [cljfmt.test-util.common :as common]))
 
-(defmethod test/assert-expr 'reformats-to? [msg form]
+(defmethod test/assert-expr 'reformats-to? [_env msg form]
   `(let [report-result# (common/reformats-to-event ~msg ~form)]
      (test/do-report report-result#)
      (= :pass (:type report-result#))))

--- a/cljfmt/test/cljfmt/test_util/cljs.cljc
+++ b/cljfmt/test/cljfmt/test_util/cljs.cljc
@@ -1,7 +1,0 @@
-(ns cljfmt.test-util.cljs
-  (:require [cljs.test :as test]
-            [cljfmt.test-util.common :as common]))
-
-#?(:clj
-   (defmethod test/assert-expr 'reformats-to? [_env msg form]
-     `(test/do-report (common/assert-reformats-to ~msg ~@(rest form)))))

--- a/cljfmt/test/cljfmt/test_util/common.cljc
+++ b/cljfmt/test/cljfmt/test_util/common.cljc
@@ -1,15 +1,16 @@
 (ns cljfmt.test-util.common
   (:require [clojure.string :as str]
-            [cljfmt.core :refer [reformat-string]]))
+            [cljfmt.core :as cljfmt]))
 
-(defn assert-reformats-to
-  ([msg in-lines expected-lines]
-   (assert-reformats-to msg in-lines expected-lines {}))
-  ([msg in-lines expected-lines options]
-   (let [input        (str/join "\n" in-lines)
-         actual       (reformat-string input options)
-         actual-lines (str/split actual #"\n" -1)]
-     {:type (if (= expected-lines actual-lines) :pass :fail)
-      :message  msg
-      :expected expected-lines
-      :actual   actual-lines})))
+(defmacro reformats-to-event [msg form]
+  `(let [in-lines# ~(nth form 1)
+         expected-lines# ~(nth form 2)
+         options# ~(nth form 3 {})
+         actual-lines# (-> (str/join "\n" in-lines#)
+                           (cljfmt/reformat-string options#)
+                           (str/split #"\n" -1))
+         result# (= expected-lines# actual-lines#)]
+     {:type (if result# :pass :fail)
+      :message ~msg
+      :expected expected-lines#
+      :actual actual-lines#}))


### PR DESCRIPTION
Obviate the need for a compensating namespace require in core-test
for ClojureScript by switching from a function to a macro for common
code supporting reformats-to? assert-expr.

Rename test_util/cljs.cljc to test_util/cljs.clj to avoid unnecessary
complexity.