### PR TITLE
Refactor indents sorting to improve performance

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -312,7 +312,7 @@
 (defn- custom-indent [zloc indents context]
   (if (empty? indents)
     (list-indent zloc)
-    (let [indenter (->> (sort-by indent-order indents)
+    (let [indenter (->> indents
                         (map #(make-indenter % context))
                         (apply some-fn))]
       (or (indenter zloc)
@@ -342,10 +342,11 @@
   ([form indents]
    (indent form indents {}))
   ([form indents alias-map]
-   (let [ns-name (find-namespace (z/edn form))]
+   (let [ns-name (find-namespace (z/edn form))
+         sorted-indents (sort-by indent-order indents)]
      (transform form edit-all should-indent? 
-                #(indent-line % indents {:alias-map alias-map 
-                                         :ns-name ns-name})))))
+                #(indent-line % sorted-indents {:alias-map alias-map
+                                                :ns-name ns-name})))))
 
 (defn- map-key? [zloc]
   (and (z/map? (z/up zloc))


### PR DESCRIPTION
I've been profiling the code and found that the call to `sort-by` is very expensive and is called with a high frequency. I believe this call can safely be moved up the call hierarchy from `custom-indent` to `indent` so that it is only called once per call to `indent`.

Benchmark:

```clojure
(require '[criterium.core :as crit])
(def sample (slurp "https://raw.githubusercontent.com/clojure/clojure/master/src/clj/clojure/core.clj"))
(crit/quick-bench 
 (cljfmt/reformat-string sample
                         {:indentation? true
                          :remove-consecutive-blank-lines? false
                          :remove-surrounding-whitespace? false
                          :insert-missing-whitespace? false
                          :remove-trailing-whitespace? false}))
```

Before:

```
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 6.417959 sec
    Execution time std-deviation : 49.024102 ms
   Execution time lower quantile : 6.385542 sec ( 2.5%)
   Execution time upper quantile : 6.499747 sec (97.5%)
                   Overhead used : 7.166550 ns

Found 1 outliers in 6 samples (16.6667 %)
	low-severe	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers
```

After:

```
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 1.222197 sec
    Execution time std-deviation : 107.052812 ms
   Execution time lower quantile : 1.119392 sec ( 2.5%)
   Execution time upper quantile : 1.350514 sec (97.5%)
                   Overhead used : 7.166550 ns
```

Benchmark:

```clojure
(crit/quick-bench
   (cljfmt/reformat-string sample
                           {:indentation? true
                            :remove-consecutive-blank-lines? true
                            :remove-surrounding-whitespace? true
                            :insert-missing-whitespace? true
                            :remove-trailing-whitespace? true}))
```

Before:

```
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 6.803126 sec
    Execution time std-deviation : 110.233777 ms
   Execution time lower quantile : 6.734209 sec ( 2.5%)
   Execution time upper quantile : 6.983225 sec (97.5%)
                   Overhead used : 7.166550 ns

Found 1 outliers in 6 samples (16.6667 %)
	low-severe	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers
```

After:

```
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 1.536204 sec
    Execution time std-deviation : 145.444873 ms
   Execution time lower quantile : 1.398777 sec ( 2.5%)
   Execution time upper quantile : 1.692483 sec (97.5%)
                   Overhead used : 7.166550 ns
```