### PR TITLE
Add split-keypairs-over-multiple-lines option

### DIFF
--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -156,6 +156,7 @@
    :remove-surrounding-whitespace?        true
    :remove-trailing-whitespace?           true
    :remove-consecutive-blank-lines?       true
+   :split-keypairs-over-multiple-lines?   false
    :indents   cljfmt/default-indents
    :alias-map {}})
 
@@ -197,7 +198,10 @@
     :id :insert-missing-whitespace?]
    [nil "--[no-]remove-consecutive-blank-lines"
     :default (:remove-consecutive-blank-lines? default-options)
-    :id :remove-consecutive-blank-lines?]])
+    :id :remove-consecutive-blank-lines?]
+   [nil "--[no-]split-keypairs-over-multiple-lines"
+    :default (:split-keypairs-over-multiple-lines? default-options)
+    :id :split-keypairs-over-multiple-lines?]])
 
 (defn- file-exists? [path]
   (.exists (io/as-file path)))


### PR DESCRIPTION
Hi @weavejester 
I noticed that the `split-keypairs-over-multiple-lines?` options is available but missing from the `cli-options` e.g.
```clojure
;; sample config for use with `deps.edn` 
 :cljfmt
  {:main-opts ["-m" "cljfmt.main"
               "--indentation"
               "--insert-missing-whitespace"
               "--ansi"
               "--remove-consecutive-blank-lines"
               "--remove-multiple-non-indenting-spaces"
               "--remove-surrounding-whitespace"
               "--remove-trailing-whitespace"
               "--split-keypairs-over-multiple-lines" ;; NOTE: this option is not support
              ]
   :replace-deps
   {cljfmt/cljfmt {:mvn/version "0.8.0"}}}
```
When running with the above config from Clojure project using `deps.edn`

```shell
$clj -M:cljfmt
[Unknown option: "--split-keypairs-over-multiple-lines"]
```
This PR ensure that this option is available from the CLI

e.g. when run without any argument (from this PR) I can get the proper support :

```
$clj -M:cljfmt

cljfmt [OPTIONS] COMMAND [PATHS ...]
      --help
      --file-pattern FILE_PATTERN                  \.clj[csx]?$
      --indents INDENTS_PATH
      --alias-map ALIAS_MAP_PATH
      --project-root PROJECT_ROOT                  .
      --[no-]ansi
      --[no-]indentation
      --[no-]remove-multiple-non-indenting-spaces
      --[no-]remove-surrounding-whitespace
      --[no-]remove-trailing-whitespace
      --[no-]insert-missing-whitespace
      --[no-]remove-consecutive-blank-lines
      --[no-]split-keypairs-over-multiple-lines
```