### PR TITLE
Add `block 0` indentation for `delay`

### DIFF
--- a/cljfmt/resources/cljfmt/indents/clojure.clj
+++ b/cljfmt/resources/cljfmt/indents/clojure.clj
@@ -23,6 +23,7 @@
  defstruct       [[:block 1]]
  deftest         [[:inner 0]]
  deftype         [[:block 2] [:inner 1]]
+ delay           [[:block 0]]
  do              [[:block 0]]
  doseq           [[:block 1]]
  dotimes         [[:block 1]]


### PR DESCRIPTION
The Clojure Style Guide, which this project attempts to help
developers follow, specifies that we should use 2 spaces to indent
the bodies of forms that have body parameters[0]. This quite clearly
applies to `clojure.core/delay`, based on the docstring and behavior
of this macro. I've chosen `:block` instead of `:inner` here since

```clojure
(delay (f0)
       (f1))
```

is better than the following in that the following incorrectly
signifies that the first argument is somehow different that the
subsequent ones.

```clojure
(delay (f0)
  (f1))
```

Also compare to the indent for `clojure.core/do`.

[0] https://guide.clojure.style/#body-indentation