### PR TITLE
Improve heuristics for finding ns form

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -41,16 +41,16 @@
   (nil? (z/up* zloc)))
 
 (defn- top? [zloc]
-  (and zloc (not= (z/node zloc) (z/root zloc))))
+  (some-> zloc z/up root?))
 
-(defn- top [zloc]
+(defn- root [zloc]
   (if (root? zloc) zloc (recur (z/up zloc))))
 
 (defn- clojure-whitespace? [zloc]
   (z/whitespace? zloc))
 
 (defn- surrounding-whitespace? [zloc]
-  (and (top? (z/up zloc))
+  (and (not (top? zloc))
        (surrounding? zloc clojure-whitespace?)))
 
 (defn remove-surrounding-whitespace [form]
@@ -220,7 +220,9 @@
        (= 'ns (z/sexpr zloc))))
 
 (defn- ns-form? [zloc]
-  (some-> zloc z/down ns-token?))
+  (and (top? zloc)
+       (= (z/tag zloc) :list)
+       (some-> zloc z/down ns-token?)))
 
 (defn- indent-matches? [key sym]
   (if (symbol? sym)
@@ -334,7 +336,7 @@
       zloc)))
 
 (defn- find-namespace [zloc]
-  (some-> zloc top (z/find z/next ns-form?) z/down z/next z/sexpr))
+  (some-> zloc root (z/find z/next ns-form?) z/down z/next z/sexpr))
 
 (defn indent
   ([form]

--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -336,7 +336,7 @@
       zloc)))
 
 (defn- find-namespace [zloc]
-  (some-> zloc root (z/find z/next ns-form?) z/down z/next z/sexpr))
+  (some-> zloc root z/down (z/find z/right ns-form?) z/down z/next z/sexpr))
 
 (defn indent
   ([form]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -281,7 +281,33 @@
           "                  (prn x)))"]
          {:indents {'thing.core/defrecord [[:inner 0]]}
           #?@(:cljs [:alias-map {"t" "thing.core"}])})
-        "applies custom indentation to namespaced defrecord"))
+        "applies custom indentation to namespaced defrecord")
+    (is (reformats-to?
+         ["(let [ns subs]"
+          "  (ns \"string\"))"
+          ""
+          "(ns thing.core)"
+          ""
+          "(defthing foo [x]"
+          "(+ x 1))"]
+         ["(let [ns subs]"
+          "  (ns \"string\"))"
+          ""
+          "(ns thing.core)"
+          ""
+          "(defthing foo [x]"
+          "  (+ x 1))"]
+         {:indents {'thing.core/defthing [[:inner 0]]
+                    'let [[:inner 0]]}
+          #?@(:cljs [:alias-map {}])})
+        "recognises the current namespace as part of a qualifed indent spec, even if preceded by a local var named ns")
+    (is (reformats-to?
+         ["(let [ns (range 10)]"
+          "  (reduce + ns"
+          "          ))"]
+         ["(let [ns (range 10)]"
+          "  (reduce + ns))"]
+         "doesn't throw with local vars named ns bound to expressions")))
 
   (testing "function #() syntax"
     (is (reformats-to?


### PR DESCRIPTION
The helper that finds the namespace form was too broad in what it would accept.

For example, if the first `ns` token it found looked like the following, it would consider it an ns form:

```clojure
(let [ns (range 100)] ,,,)
```

In this case an exception was thrown because cljfmt tries to treat `(range 100)` as the ns name, and calls `clojure.core/name` on it.

Even if the next expression responded to `clojure.core/name`, weird things could happen (see tests) because cljfmt would use the wrong ns name:

```clojure
(let [ns another-local-var] ,,,)
```

This commit makes the heuristics for finding a ns form more restrictive. Now, an ns form must be ~a list that starts with at least two tokens, the token ns and another token following it~ a top-level list that starts with the `ns` token.

```clojure
(ns my-ns ,,,)
```

I may run into this more than others because I work on clojure-lsp and a little on clj-kondo, and so it's common to have local vars named ns. Also, clojure-lsp supports formatting of individual defns, separate from the rest of their namespace, which means the true ns form is missing.

Fixes #247.