### PR TITLE
Add namespace sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ selectively enabled or disabled:
   true if cljfmt should break hashmaps onto multiple lines. This will
   convert `{:a 1 :b 2}` to `{:a 1\n:b 2}`. Defaults to false.
 
+* `:sort-ns-references?` -
+  true if cljfmt should sort `ns` blocks `:require`, `:require-macros`, `:use`,
+  and `:import` by namespace. This will convert `(ns (:require [c] b [a.b.c]))`
+  to `(ns (:require [a.b.c] b [c]))`. Defaults to false.
+
 You can also configure the behavior of cljfmt:
 
 * `:paths` - determines which directories to include in the
@@ -220,7 +225,7 @@ Indentation types are:
 * `:inner` -
   two character indentation applied to form arguments at a depth
   relative to a form symbol
-  
+
 * `:block` -
   first argument aligned indentation applied to form arguments at form
   depth 0 for a symbol
@@ -235,9 +240,9 @@ Form depth is the nested depth of any element within the form.
 A contrived example will help to explain depth:
 
 ```clojure
-(foo 
+(foo
  bar
- (baz 
+ (baz
   (qux plugh)
   corge)
  (grault

--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -400,6 +400,90 @@
 (defn remove-multiple-non-indenting-spaces [form]
   (transform form edit-all non-indenting-whitespace? replace-with-one-space))
 
+(def ^:private ns-reference-symbols
+  #{:import :require :require-macros :use})
+
+(defn- ns-reference? [zloc]
+  (and (z/list? zloc)
+       (some-> zloc z/up ns-form?)
+       (-> zloc z/sexpr first ns-reference-symbols)))
+
+(defn- re-indexes [re s]
+  (let [matcher    #?(:clj  (re-matcher re s)
+                      :cljs (js/RegExp. (.-source re) "g"))
+        next-match #?(:clj  #(when (.find matcher)
+                               [(.start matcher) (.end matcher)])
+                      :cljs #(when-let [result (.exec matcher s)]
+                               [(.-index result) (.-lastIndex matcher)]))]
+    (take-while some? (repeatedly next-match))))
+
+(defn- re-seq-matcher [re charmap coll]
+  {:pre (every? charmap coll)}
+  (let [s (apply str (map charmap coll))
+        v (vec coll)]
+    (for [[start end] (re-indexes re s)]
+      {:value (subvec v start end)
+       :start start
+       :end   end})))
+
+(defn- find-elements-with-comments [nodes]
+  (re-seq-matcher #"(CNS*)*E(S*C)?"
+                  #(case (n/tag %)
+                     (:whitespace :comma) \S
+                     :comment \C
+                     :newline \N
+                     \E)
+                  nodes))
+
+(defn- splice-into [coll splices]
+  (letfn [(splice [v i splices]
+            (when-let [[{:keys [value start end]} & splices] (seq splices)]
+              (lazy-cat (subvec v i start) value (splice v end splices))))]
+    (splice (vec coll) 0 splices)))
+
+(defn- add-newlines-after-comments [nodes]
+  (mapcat #(if (n/comment? %) [% (n/newlines 1)] [%]) nodes))
+
+(defn- remove-newlines-after-comments [nodes]
+  (mapcat #(when-not (and %1 (n/comment? %1) (n/linebreak? %2)) [%2])
+          (cons nil nodes)
+          nodes))
+
+(defn- sort-node-arguments-by [f nodes]
+  (let [nodes  (add-newlines-after-comments nodes)
+        args   (rest (find-elements-with-comments nodes))
+        sorted (sort-by f (map :value args))]
+    (->> sorted
+         (map #(assoc %1 :value %2) args)
+         (splice-into nodes)
+         (remove-newlines-after-comments))))
+
+(defn- update-children [zloc f]
+  (let [node (z/node zloc)]
+    (z/replace zloc (n/replace-children node (f (n/children node))))))
+
+(defn- nodes-string [nodes]
+  (apply str (map n/string nodes)))
+
+(defn- unpack-metadata-and-uneval [nodes]
+  (mapcat (fn [node]
+            (case (n/tag node)
+              :meta (rest (n/children node))
+              :uneval (n/children node)
+              [node])) nodes))
+
+(defn- node-sort-string [nodes]
+  (-> (remove (some-fn n/comment? n/whitespace?) (unpack-metadata-and-uneval nodes))
+      (nodes-string)
+      (str/replace #"[\[\]\(\)\{\}]" "")
+      (str/trim)))
+
+(defn sort-arguments [zloc]
+  (update-children zloc #(sort-node-arguments-by node-sort-string %)))
+
+(defn sort-ns-references [form]
+  (transform form edit-all ns-reference? sort-arguments))
+
 (def default-options
   {:indentation?                          true
    :insert-missing-whitespace?            true
@@ -407,6 +491,7 @@
    :remove-multiple-non-indenting-spaces? false
    :remove-surrounding-whitespace?        true
    :remove-trailing-whitespace?           true
+   :sort-ns-references?                   false
    :split-keypairs-over-multiple-lines?   false
    :indents   default-indents
    :alias-map {}})
@@ -417,6 +502,8 @@
   ([form opts]
    (let [opts (merge default-options opts)]
      (-> form
+         (cond-> (:sort-ns-references? opts)
+           sort-ns-references)
          (cond-> (:split-keypairs-over-multiple-lines? opts)
            (split-keypairs-over-multiple-lines))
          (cond-> (:remove-consecutive-blank-lines? opts)

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -158,7 +158,17 @@
   {:project-root "."
    :file-pattern #"\.clj[csx]?$"
    :ansi?        true
-   :parallel?    false})
+   :parallel?    false
+   :indentation? true
+   :insert-missing-whitespace?            true
+   :remove-multiple-non-indenting-spaces? false
+   :remove-surrounding-whitespace?        true
+   :remove-trailing-whitespace?           true
+   :remove-consecutive-blank-lines?       true
+   :sort-ns-references?                   false
+   :split-keypairs-over-multiple-lines?   false
+   :indents   cljfmt/default-indents
+   :alias-map {}})
 
 (defn merge-default-options [options]
   (-> (merge default-options options)
@@ -201,6 +211,9 @@
    [nil "--[no-]remove-consecutive-blank-lines"
     :default (:remove-consecutive-blank-lines? cljfmt/default-options)
     :id :remove-consecutive-blank-lines?]
+   [nil "--[no-]sort-ns-references"
+    :default (:sort-ns-references? default-options)
+    :id :sort-ns-references?]
    [nil "--[no-]split-keypairs-over-multiple-lines"
     :default (:split-keypairs-over-multiple-lines? cljfmt/default-options)
     :id :split-keypairs-over-multiple-lines?]])


### PR DESCRIPTION
An attempt to add namespace sorting in `ns` reference blocks. This is one of the features requested in #13.

I saw it was previously implemented in #95 and #113, but both PRs appear stale and neither looks like they handle the cases I'm interested in. Most importantly handling comments and all libspec variants (e.g. `a.b.c`, `[a.b.c ...]`, `"npm-dependency"`) and all flavours of reference blocks (i.e. `:require`, `:require-macros`, `:use`, `:import`).
This implementation tries to address those issues.

It tries to preserve newlines and spaces and will honour these styles:
```clj
(:require [foo] [bar])
(:require [foo]
          [bar])
(:require
  [foo]
  [bar])
```
It'll also move comments before a line and at the end of a line with the libspec element, e.g.
```clj
(:require
 ; comment for c
 c
 a ; comment for a
 b)
->
(:require
 a ; comment for a
 b
 ; comment for c
 c)
```
A messy mix of newlines and same line libspecs and comments and non-indentation whitespaces in the source file can still result in unexpected results, especially if no other options for indentation and whitespace removal are turned on, but I think those should be rare, and at that point it's really hard to guess what might be the desired formating.

I introduced a new namespace, which might not be what you want, but it seemed like those functions would enlarge `cljfmt.core` quite a bit, and since there were other ideas for ns-related improvements in #13... perhaps that's a place where they could live.

Finally, all but the last commit are preparation and (I hope) small improvements. They are orthogonal to the feature, so either can be cherry-picked or dropped.

Note: This code also assumes `ns-form?` works correctly to identify the top-level `ns` form, as #250 is already working on that I use the function as is.