### PR TITLE
Refactor indenting

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -260,7 +260,7 @@
 
 (defn- inner-indent [zloc key depth idx context]
   (let [top (nth (iterate z/up zloc) depth)]
-    (when (and (or (indent-matches? key (fully-qualified-symbol zloc context))
+    (when (and (or (indent-matches? key (fully-qualified-symbol top context))
                    (indent-matches? key (remove-namespace (form-symbol top))))
                (or (nil? idx) (index-matches-top-argument? zloc depth idx)))
       (let [zup (z/up zloc)]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -307,7 +307,21 @@
           "          ))"]
          ["(let [ns (range 10)]"
           "  (reduce + ns))"])
-        "doesn't throw with local vars named ns bound to expressions"))
+        "doesn't throw with local vars named ns bound to expressions")
+    (is (reformats-to?
+         ["(foo.bar/my-letfn [(f [x]"
+          "x)]"
+          "(let [x (f 1)]"
+          "(str x 2"
+          "3 4)))"]
+         ["(foo.bar/my-letfn [(f [x]"
+          "                     x)]"
+          "  (let [x (f 1)]"
+          "    (str x 2"
+          "         3 4)))"]
+         {:indents {'let [[:block 1]]
+                    'foo.bar/my-letfn [[:block 1] [:inner 2 0]]}})
+        "matches qualified parent form symbol"))
 
   (testing "function #() syntax"
     (is (reformats-to?


### PR DESCRIPTION
This doubles the speed for multi file processing in a native image. By separating the identification of parent form-symbols from the rule matching and using map look-ups.

Related to #254.