### PR TITLE
Refactor cljfmt options

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -400,26 +400,37 @@
 (defn remove-multiple-non-indenting-spaces [form]
   (transform form edit-all non-indenting-whitespace? replace-with-one-space))
 
+(def default-options
+  {:indentation?                          true
+   :insert-missing-whitespace?            true
+   :remove-consecutive-blank-lines?       true
+   :remove-multiple-non-indenting-spaces? false
+   :remove-surrounding-whitespace?        true
+   :remove-trailing-whitespace?           true
+   :split-keypairs-over-multiple-lines?   false
+   :indents   default-indents
+   :alias-map {}})
+
 (defn reformat-form
   ([form]
    (reformat-form form {}))
   ([form opts]
-   (-> form
-       (cond-> (:split-keypairs-over-multiple-lines? opts false)
-         (split-keypairs-over-multiple-lines))
-       (cond-> (:remove-consecutive-blank-lines? opts true)
-         remove-consecutive-blank-lines)
-       (cond-> (:remove-surrounding-whitespace? opts true)
-         remove-surrounding-whitespace)
-       (cond-> (:insert-missing-whitespace? opts true)
-         insert-missing-whitespace)
-       (cond-> (:remove-multiple-non-indenting-spaces? opts false)
-         remove-multiple-non-indenting-spaces)
-       (cond-> (:indentation? opts true)
-         (reindent (:indents opts default-indents)
-                   (:alias-map opts {})))
-       (cond-> (:remove-trailing-whitespace? opts true)
-         remove-trailing-whitespace))))
+   (let [opts (merge default-options opts)]
+     (-> form
+         (cond-> (:split-keypairs-over-multiple-lines? opts)
+           (split-keypairs-over-multiple-lines))
+         (cond-> (:remove-consecutive-blank-lines? opts)
+           remove-consecutive-blank-lines)
+         (cond-> (:remove-surrounding-whitespace? opts)
+           remove-surrounding-whitespace)
+         (cond-> (:insert-missing-whitespace? opts)
+           insert-missing-whitespace)
+         (cond-> (:remove-multiple-non-indenting-spaces? opts)
+           remove-multiple-non-indenting-spaces)
+         (cond-> (:indentation? opts)
+           (reindent (:indents opts) (:alias-map opts)))
+         (cond-> (:remove-trailing-whitespace? opts)
+           remove-trailing-whitespace)))))
 
 #?(:clj
    (defn- ns-require-form? [zloc]

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -149,16 +149,7 @@
 (def default-options
   {:project-root "."
    :file-pattern #"\.clj[csx]?$"
-   :ansi?        true
-   :indentation? true
-   :insert-missing-whitespace?            true
-   :remove-multiple-non-indenting-spaces? false
-   :remove-surrounding-whitespace?        true
-   :remove-trailing-whitespace?           true
-   :remove-consecutive-blank-lines?       true
-   :split-keypairs-over-multiple-lines?   false
-   :indents   cljfmt/default-indents
-   :alias-map {}})
+   :ansi?        true})
 
 (defn merge-default-options [options]
   (-> (merge default-options options)
@@ -182,25 +173,25 @@
     :default (:ansi? default-options)
     :id :ansi?]
    [nil "--[no-]indentation"
-    :default (:indentation? default-options)
+    :default (:indentation? cljfmt/default-options)
     :id :indentation?]
    [nil "--[no-]remove-multiple-non-indenting-spaces"
-    :default (:remove-multiple-non-indenting-spaces? default-options)
+    :default (:remove-multiple-non-indenting-spaces? cljfmt/default-options)
     :id :remove-multiple-non-indenting-spaces?]
    [nil "--[no-]remove-surrounding-whitespace"
-    :default (:remove-surrounding-whitespace? default-options)
+    :default (:remove-surrounding-whitespace? cljfmt/default-options)
     :id :remove-surrounding-whitespace?]
    [nil "--[no-]remove-trailing-whitespace"
-    :default (:remove-trailing-whitespace? default-options)
+    :default (:remove-trailing-whitespace? cljfmt/default-options)
     :id :remove-trailing-whitespace?]
    [nil "--[no-]insert-missing-whitespace"
-    :default (:insert-missing-whitespace? default-options)
+    :default (:insert-missing-whitespace? cljfmt/default-options)
     :id :insert-missing-whitespace?]
    [nil "--[no-]remove-consecutive-blank-lines"
-    :default (:remove-consecutive-blank-lines? default-options)
+    :default (:remove-consecutive-blank-lines? cljfmt/default-options)
     :id :remove-consecutive-blank-lines?]
    [nil "--[no-]split-keypairs-over-multiple-lines"
-    :default (:split-keypairs-over-multiple-lines? default-options)
+    :default (:split-keypairs-over-multiple-lines? cljfmt/default-options)
     :id :split-keypairs-over-multiple-lines?]])
 
 (defn- file-exists? [path]


### PR DESCRIPTION
The goal is to simplify option handling and reduce duplication. It also revealed a minor bug in the test suite.

Side note: I noticed that the merge of default indents and specified indents is only done in main, so using `cljfmt.core/reformat-form` programmatically will overwrite `:indents` entirely. Is that by design? I guess it makes sense to be able to start with a clean slate, but it could be surprising.