### PR TITLE
Fix unit test

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -306,8 +306,8 @@
           "  (reduce + ns"
           "          ))"]
          ["(let [ns (range 10)]"
-          "  (reduce + ns))"]
-         "doesn't throw with local vars named ns bound to expressions")))
+          "  (reduce + ns))"])
+        "doesn't throw with local vars named ns bound to expressions"))
 
   (testing "function #() syntax"
     (is (reformats-to?


### PR DESCRIPTION
The assertion message was passed as opts to reformats-to. This still
worked because (:foo "some string") yields nil, so all default options
were used, just like the test requires.