### PR TITLE
Show default values for boolean CLI options

### DIFF
--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.clojure/tools.cli "1.0.206"]
+                 [org.clojure/tools.cli "1.0.214"]
                  [org.clojure/tools.reader "1.3.6"]
                  [com.googlecode.java-diff-utils/diffutils "1.3.0"]
                  [rewrite-clj "1.1.45"]]

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -172,6 +172,8 @@
   [[nil "--help"]
    [nil "--parallel"
     :id :parallel?]
+   [nil "--project-root PROJECT_ROOT"
+    :default (:project-root default-options)]
    [nil "--file-pattern FILE_PATTERN"
     :default (:file-pattern default-options)
     :parse-fn re-pattern]
@@ -179,8 +181,6 @@
     :parse-fn cli-file-reader]
    [nil "--alias-map ALIAS_MAP_PATH"
     :parse-fn cli-file-reader]
-   [nil "--project-root PROJECT_ROOT"
-    :default (:project-root default-options)]
    [nil "--[no-]ansi"
     :default (:ansi? default-options)
     :id :ansi?]


### PR DESCRIPTION
Annoyingly this requires those two summary functions, but I think this is an important feature to show what the default configuration actually is. The functions are taken from the default functions in tools.cli, with some code thrown out that doesn't apply here.
```
cljfmt [OPTIONS] COMMAND [PATHS ...]
      --help
      --parallel
      --project-root PROJECT_ROOT                  .
      --file-pattern FILE_PATTERN                  \.clj[csx]?$
      --indents INDENTS_PATH
      --alias-map ALIAS_MAP_PATH
      --[no-]ansi                                  on
      --[no-]indentation                           on
      --[no-]remove-multiple-non-indenting-spaces  off
      --[no-]remove-surrounding-whitespace         on
      --[no-]remove-trailing-whitespace            on
      --[no-]insert-missing-whitespace             on
      --[no-]remove-consecutive-blank-lines        on
      --[no-]split-keypairs-over-multiple-lines    off
```