### PR TITLE
Fix native image build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.asc
 *.class
 .lein-*
 .nrepl-port
+reports

--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -27,6 +27,7 @@
           "-H:+ReportExceptionStackTraces"
           "-H:ReflectionConfigurationFiles=reflection.json"
           "--initialize-at-build-time"
+          "--diagnostics-mode"
           "--report-unsupported-elements-at-runtime"
           "-H:Log=registerResource:"
           "--no-fallback"

--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -37,9 +37,8 @@
           "-J-Xmx3g"]}
   :main cljfmt.main
   :profiles
-  {:uberjar
-   {:aot :all
-    :native-profile
-    {:jvm-opts ["-Dclojure.compiler.direct-linking=true"
-                "-Dclojure.spec.skip-macros=true"]}}
+  {:uberjar {:aot :all}
+   :native-image {:aot :all
+                  :jvm-opts ["-Dclojure.compiler.direct-linking=true"
+                             "-Dclojure.spec.skip-macros=true"]}
    :provided {:dependencies [[org.clojure/clojurescript "1.10.866"]]}})

--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -25,15 +25,11 @@
   {:name "cljfmt"
    :opts ["--verbose"
           "-H:+ReportExceptionStackTraces"
-          "-J-Dclojure.spec.skip-macros=true"
-          "-J-Dclojure.compiler.direct-linking=true"
           "-H:ReflectionConfigurationFiles=reflection.json"
           "--initialize-at-build-time"
           "--report-unsupported-elements-at-runtime"
           "-H:Log=registerResource:"
-          "--verbose"
           "--no-fallback"
-          "--no-server"
           "-J-Xmx3g"]}
   :main cljfmt.main
   :profiles

--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -35,11 +35,11 @@
           "--no-fallback"
           "--no-server"
           "-J-Xmx3g"]}
+  :main cljfmt.main
   :profiles
   {:uberjar
-   {:main cljfmt.main
-    :aot :all
-    :native-image
+   {:aot :all
+    :native-profile
     {:jvm-opts ["-Dclojure.compiler.direct-linking=true"
                 "-Dclojure.spec.skip-macros=true"]}}
    :provided {:dependencies [[org.clojure/clojurescript "1.10.866"]]}})


### PR DESCRIPTION
Fix the ignored `:jvm-opts` for native-image, as mentioned in #254.

Also clean up the native-image build, some options have no effect or didn't work as intended on current GraalVM versions (21.2.0+, latest is 22.1).
