### PR TITLE
Specify :main for native-image target

### DIFF
--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -36,6 +36,7 @@
   {:uberjar {:main cljfmt.main
              :aot :all}
    :native-image {:aot :all
+                  :main cljfmt.main
                   :jvm-opts ["-Dclojure.compiler.direct-linking=true"
                              "-Dclojure.spec.skip-macros=true"]}
    :provided {:dependencies [[org.clojure/clojurescript "1.11.4"]]}})


### PR DESCRIPTION
I'd like to I want to compile cljfmt using graalvm to create a binary.

I'm probably doing it wrong, but this is what I'm doing:

```bash
## setting GRAAVLM_HOME appropriately
cd cljfmt
lein native-image
```

I get the following NPE error:

```
java.lang.NullPointerException: Cannot invoke "clojure.lang.Named.getName()" because "x" is null
```

Full output with error:

```
% lein native-image
Compiling cljfmt.core
Compiling cljfmt.diff
Compiling cljfmt.main
Compiling ClojureScript...
Compiling ["target/out/tests.js"] from ["src" "test"]...
WARNING: rewrite-clj.zip/edn is deprecated at line 34 src/cljfmt/core.cljc
WARNING: rewrite-clj.zip/edn is deprecated at line 347 src/cljfmt/core.cljc
Successfully compiled ["target/out/tests.js"] in 3.014 seconds.
Compiling ClojureScript...
java.lang.NullPointerException: Cannot invoke "clojure.lang.Named.getName()" because "x" is null
 at clojure.core$name.invokeStatic (core.clj:1597)
    clojure.core$name.invoke (core.clj:1591)
    leiningen.native_image$native_image.invokeStatic (native_image.clj:66)
    leiningen.native_image$native_image.doInvoke (native_image.clj:57)
    clojure.lang.RestFn.invoke (RestFn.java:410)
    clojure.lang.AFn.applyToHelper (AFn.java:154)
    clojure.lang.RestFn.applyTo (RestFn.java:132)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.core$apply.invokeStatic (core.clj:669)
    clojure.core$apply.invoke (core.clj:662)
    leiningen.core.main$partial_task$fn__7340.doInvoke (main.clj:284)
    clojure.lang.RestFn.invoke (RestFn.java:410)
    clojure.lang.AFn.applyToHelper (AFn.java:154)
    clojure.lang.RestFn.applyTo (RestFn.java:132)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:31)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:669)
    clojure.core$apply.invoke (core.clj:662)
    leiningen.core.main$apply_task.invokeStatic (main.clj:334)
    leiningen.core.main$apply_task.invoke (main.clj:320)
    leiningen.core.main$resolve_and_apply.invokeStatic (main.clj:343)
    leiningen.core.main$resolve_and_apply.invoke (main.clj:336)
    leiningen.core.main$_main$fn__7429.invoke (main.clj:453)
    leiningen.core.main$_main.invokeStatic (main.clj:442)
    leiningen.core.main$_main.doInvoke (main.clj:439)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.core$apply.invokeStatic (core.clj:667)
    clojure.main$main_opt.invokeStatic (main.clj:514)
    clojure.main$main_opt.invoke (main.clj:510)
    clojure.main$main.invokeStatic (main.clj:664)
    clojure.main$main.doInvoke (main.clj:616)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.main.main (main.java:40)
```

Specifying `:main` in for the `:native-image` target fixes this (as submitted in the PR).

System details:

graalvm: graalvm-ce-java17-22.2.0-dev

```
% lein --version
Leiningen 2.9.8 on Java 16.0.2 OpenJDK 64-Bit Server VM
```

This is on macOS with an M1 chip.
```
% sw_vers
ProductName:	macOS
ProductVersion:	12.4
BuildVersion:	21F79

% uname -a
Darwin koke.local 21.5.0 Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:29 PDT 2022; root:xnu-8020.121.3~4/RELEASE_ARM64_T8101 arm64
```

Please feel free to disregard the PR if this is just pebkac. I'm happy to update the README with build instructions to help the hapless like me :)
