### PR TITLE
Allow to pass --sort-ns-references option

### DIFF
--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -204,7 +204,10 @@
     :id :remove-consecutive-blank-lines?]
    [nil "--[no-]split-keypairs-over-multiple-lines"
     :default (:split-keypairs-over-multiple-lines? cljfmt/default-options)
-    :id :split-keypairs-over-multiple-lines?]])
+    :id :split-keypairs-over-multiple-lines?]
+   [nil "--[no-]sort-ns-references"
+    :default (:sort-ns-references? cljfmt/default-options)
+    :id :sort-ns-references?]])
 
 (defn- file-exists? [path]
   (.exists (io/as-file path)))


### PR DESCRIPTION
Hi!
I don't know if it was intentional but it lacks the possibility to use the option `--sort-ns-references`