### PR TITLE
Add configuration file to CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ clojure -Sdeps '{:deps {cljfmt {:mvn/version "0.9.0"}}}' \
 
 ## Configuration
 
+### Leiningen
 You can configure lein-cljfmt by adding a `:cljfmt` map to your
 project:
 
@@ -108,6 +109,13 @@ project:
 :cljfmt {}
 ```
 
+### Command line
+You can configure `cljfmt` by placing a `.cljfmt.edn` or `.cljfmt.clj`
+file in the directory where you run the command, or any parent
+directory. The first file in the hierarchy will be used, files in
+higher up parent directories are ignored.
+
+### Rules
 cljfmt has several different formatting rules, and these can be
 selectively enabled or disabled:
 


### PR DESCRIPTION
Similar to the Leiningen configuration it would be useful to put rules in a configuration file, which can then be version controlled and honoured by tools that only run cljfmt in the directory, without taking command line arguments.

The file .cljfmt.edn is looked for in the current directory and all its parent directories, the first file found is used.

Command line options override the options in the configuration file, command line indents are added to the default indents or those found inside the configuration file.

The configuration file can also be specified at the command line directly to override looking for it.

This addresses #256.