### PR TITLE
Combine `:alias-maps` setting with namespace aliases

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -553,8 +553,8 @@
    (reformat-string form-string {}))
   ([form-string options]
    (let [parsed-form (p/parse-string-all form-string)
-         alias-map   #?(:clj (or (:alias-map options)
-                                 (alias-map-for-form parsed-form))
+         alias-map   #?(:clj (merge (alias-map-for-form parsed-form)
+                                    (:alias-map options))
                         :cljs (:alias-map options))]
      (-> parsed-form
          (reformat-form (cond-> options

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -1143,7 +1143,39 @@
         ":three four}"]
        ["{:one two #_comment"
         " :three four}"]
-       {:split-keypairs-over-multiple-lines? true})))
+       {:split-keypairs-over-multiple-lines? true}))
+  #?(:clj
+     (is (reformats-to?
+          ["(ns foo.bar"
+           "  (:require"
+           "   [some.lib :as lib]"
+           "   [other.lib :as other]))"
+           "(lib/block2 1 2"
+           "      3 4)"
+           "(other/block1 1"
+           "     2"
+           "        3 4)"
+           "(other/overridden 1"
+           "  2"
+           "  3 4)"]
+          ["(ns foo.bar"
+           "    (:require"
+           "     [other.lib :as other]"
+           "     [some.lib :as lib]))"
+           "(lib/block2 1 2"
+           "  3 4)"
+           "(other/block1 1"
+           "  2"
+           "  3 4)"
+           "(other/overridden 1"
+           "  2"
+           "  3 4)"]
+          {:alias-map {"other" "another.lib"}
+           :sort-ns-references? true
+           :indents   {'block1                 [[:block 1]]
+                       'other.lib/overridden   [[:block 2]] ;; This one is ignored
+                       'another.lib/overridden [[:block 1]] ;; As this one overrides.
+                       'some.lib/block2        [[:block 2]]}}))))
 
 (deftest test-parsing
   (is (reformats-to?


### PR DESCRIPTION
Previously, if the `:alias-maps` setting was provided (even if it's an empty map) then only that map is used to look up indentation rules.

This means that `:indents` rules defined with a namespaced symbol only work if the var usage is fully qualified. In the common case of `(:require [foo.bar :as f])` cljfmt would not indent `f/something` according to the `:indents`.

With this change, the setting has the last word but the aliases in the file are not ignored.