### PR TITLE
Fix #292: babashka compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,12 @@ jobs:
         uses: DeLaGuardo/setup-clojure@10.1
         with:
           lein: 2.9.10
+          bb: latest
 
       - name: Execute tests
         working-directory: ./cljfmt
         run: lein test
+
+      - name: Execute babashka tests
+        working-directory: ./cljfmt
+        run: bb test

--- a/cljfmt/bb.edn
+++ b/cljfmt/bb.edn
@@ -1,0 +1,14 @@
+{:deps {cljfmt/cljfmt {:local/root "."}}
+ :tasks
+ {test {:doc "Run babashka tests"
+        :extra-deps {eftest/eftest {:mvn/version "0.6.0"}}
+        :extra-paths ["test"]
+        :requires ([eftest.runner :refer [find-tests run-tests]])
+        :task (let [{:keys [fail error]} (run-tests
+                                          (find-tests "test")
+                                          (when-not (System/console)
+                                            ;; better output in github actions
+                                            {:report clojure.test/report}))]
+                (when (or (pos? fail)
+                          (pos? error))
+                  (throw (ex-info "Tests failed" {:babashka/exit 1}))))}}}

--- a/cljfmt/deps.edn
+++ b/cljfmt/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "resources"],
+ :deps
+ {org.clojure/clojure {:mvn/version "1.10.3"},
+  org.clojure/tools.cli {:mvn/version "1.0.214"},
+  org.clojure/tools.reader {:mvn/version "1.3.6"},
+  com.googlecode.java-diff-utils/diffutils {:mvn/version "1.3.0"},
+  rewrite-clj/rewrite-clj {:mvn/version "1.1.45"}}}

--- a/cljfmt/src/cljfmt/diff.bb
+++ b/cljfmt/src/cljfmt/diff.bb
@@ -1,0 +1,13 @@
+(ns cljfmt.diff)
+
+(defn throw-not-implemented []
+  (throw (ex-info "Not implemented in the babashka version of cljfmt yet" {})))
+
+(defn unified-diff
+  ([_filename _original _revised]
+   (throw-not-implemented))
+  ([_filename _original _revised _context]
+   (throw-not-implemented)))
+
+(defn colorize-diff [_diff-text]
+  (throw-not-implemented))

--- a/cljfmt/test/cljfmt/test_util/cljs.cljc
+++ b/cljfmt/test/cljfmt/test_util/cljs.cljc
@@ -1,5 +1,5 @@
 (ns cljfmt.test-util.cljs
-  (:require [cljs.test :as test]
+  (:require [clojure.test :as test]
             [cljfmt.test-util.common :as common]))
 
 #?(:clj


### PR DESCRIPTION
Hi @weavejester - this fixes and tests babashka compatibility.

I took the liberty to add a generated `deps.edn` based off the `project.clj`. This makes testing this library as a babashka dependency easier but also benefits `deps.edn` users as this library can be used as a git dep. To re-generate the `deps.edn`, all you have to do is run `bb gen-deps`.

Also added: a Github CI config file for testing this library with babashka. I did not know how to work with Travis.
cc @lread 