### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prepare java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@10.1
+        with:
+          lein: 2.9.10
+
+      - name: Execute tests
+        working-directory: ./cljfmt
+        run: lein test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: clojure
-before_install: yes | sudo lein upgrade && cd cljfmt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cljfmt
 
-[![Build Status](https://travis-ci.org/weavejester/cljfmt.svg?branch=master)](https://travis-ci.org/weavejester/cljfmt)
+![Build Status](https://github.com/weavejester/cljfmt/actions/workflows/test.yml/badge.svg)
 
 cljfmt is a tool for formatting Clojure code [idiomatically][].
 


### PR DESCRIPTION
Prompted by #293, this seems as good a repository as any to test CI via GitHub Actions.