### PR TITLE
Fix CLJS tests (fixes #296)

### DIFF
--- a/cljfmt/bb.edn
+++ b/cljfmt/bb.edn
@@ -3,12 +3,9 @@
  {test {:doc "Run babashka tests"
         :extra-deps {eftest/eftest {:mvn/version "0.6.0"}}
         :extra-paths ["test"]
-        :requires ([eftest.runner :refer [find-tests run-tests]])
-        :task (let [{:keys [fail error]} (run-tests
-                                          (find-tests "test")
-                                          (when-not (System/console)
-                                            ;; better output in github actions
-                                            {:report clojure.test/report}))]
+        :requires ([clojure.test :as t]
+                   [cljfmt.core-test])
+        :task (let [{:keys [fail error]} (t/run-tests 'cljfmt.core-test)]
                 (when (or (pos? fail)
                           (pos? error))
                   (throw (ex-info "Tests failed" {:babashka/exit 1}))))}}}

--- a/cljfmt/test/cljfmt/test_util/cljs.cljc
+++ b/cljfmt/test/cljfmt/test_util/cljs.cljc
@@ -1,5 +1,5 @@
 (ns cljfmt.test-util.cljs
-  (:require [clojure.test :as test]
+  (:require [cljs.test :as test]
             [cljfmt.test-util.common :as common]))
 
 #?(:clj


### PR DESCRIPTION
This fixes the tests like they were prior to #293. Fixes #296. 

This does _not_ address the problem that in case of a failing CLJS test, the exit code is non-zero since I want to keep this PR as minimal as possible.