### PR TITLE
Load cljfmt file with :load-dotfile? setting

### DIFF
--- a/lein-cljfmt/src/leiningen/cljfmt.clj
+++ b/lein-cljfmt/src/leiningen/cljfmt.clj
@@ -21,6 +21,9 @@
 (defn- merge-default-options [options]
   (config/merge-configs config/default-config options))
 
+(defn- merge-file-options [{:keys [load-config-file?] :as options}]
+  (config/merge-configs (when load-config-file? (config/load-config)) options))
+
 (defn ^:no-project-needed cljfmt
   "Format Clojure source files."
   [project command & paths]
@@ -30,6 +33,7 @@
         options (-> (:cljfmt project)
                     (assoc :paths paths)
                     (assoc :project-root (:root project))
+                    (merge-file-options)
                     (merge-default-options))]
     (if leiningen.core.main/*info*
       (execute-command command options)


### PR DESCRIPTION
Fixes issue #301 

Add option for lein cljfmt to read from the same .cljfmt.edn file as the cli version.