### PR TITLE
Add uberjar release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,27 @@ version: 2.1
 orbs:
   win: circleci/windows@5.0
 jobs:
+  uberjar:
+     docker:
+      - image: cimg/clojure:1.11.1-openjdk-17.0
+     working_directory: ~/repo
+     steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - uberjar-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
+      - run:
+          name: Build uberjar
+          working_directory: ~/repo/cljfmt
+          command: lein uberjar
+      - persist_to_workspace:
+          root: cljfmt/target
+          paths:
+            - cljfmt-*-standalone.jar
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: uberjar-{{ checksum "deps.edn" }}-{{ checksum ".circleci/config.yml" }}
   linux_amd64:
     docker:
       - image: cimg/clojure:1.11.1-openjdk-17.0
@@ -276,6 +297,12 @@ workflows:
   version: 2
   compile_and_release:
     jobs:
+      - uberjar:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v?\d+\.\d+\.\d+$/
       - linux_amd64:
           filters:
             branches:
@@ -308,6 +335,7 @@ workflows:
               only: /^v?\d+\.\d+\.\d+$/
       - publish_release:
           requires:
+            - uberjar
             - linux_amd64
             - linux_aarch64
             - macos_amd64


### PR DESCRIPTION
Hi  weavejester,

Would you mind add uberjar release to github? The reasoning is pretty much same as https://github.com/borkdude/jet/issues/91 . I'm trying to package cljfmt for nixos, without uberjar, the process is cumbersome and tricky due to nixos's nature on reproducibility. 

By having the uberjar, we can just reuse nixpgks' builtin buildGraalvmNativeImage without any hassle:

https://github.com/NixOS/nixpkgs/blob/3cfc4db1e07471f6718a086d93c60db857bec1ba/pkgs/development/tools/jet/default.nix

this is someone's effrot to package cljfmt without uberjar, (need to patch project.clj, prebuild deps etc...):
https://github.com/adamcstephens/nix-sandbox/blob/25ae1cca55ae39f21ec4a6328da5bae95070bfb1/packages/cljfmt/default.nix
with uberjar, it'd be much easier for example:
https://github.com/sg-qwt/nixos/blob/main/packages/cljfmt/default.nix

I don't have exact circle ci env to test the pipeline, but the goal is just to have a xxx-standlone.jar in the release. Feel free to edit or make a new one if any of the pipeline syntax is wrong.

Thanks
