### PR TITLE
Configuration option for two space list indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,21 @@ In order to load the standard configuration file from Leiningen, add the
   other references in the `ns` forms at the top of your namespaces.
   Defaults to false.
 
+* `:function-arguments-indentation` -
+  - `:community` if cljfmt should follow the [community style recommendation][]
+    to indent function/macro arguments by a single space when there
+    are no arguments on the same line as the function name.
+  - `:cursive` if two spaces should be used instead, unless the first
+    thing in the list (not counting metadata) is a data structure
+    literal. This should replicate Cursive's default behaviour.
+  - `:zprint` if two spaces should be used instead if the first thing
+    in the list is a symbol or keyword. This should replicate zprint's
+    default behaviour.
+
+  Defaults to `:community`
+
 [indents.md]: docs/INDENTS.md
+[community style recommendation]: https://guide.clojure.style/#one-space-indent
 
 ### Runtime Options
 

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -51,7 +51,15 @@
     :id :split-keypairs-over-multiple-lines?]
    [nil "--[no-]sort-ns-references"
     :default (:sort-ns-references? defaults)
-    :id :sort-ns-references?]])
+    :id :sort-ns-references?]
+   [nil "--function-arguments-indentation STYLE"
+    "STYLE may be community, cursive, or zprint"
+    :default (:function-arguments-indentation defaults)
+    :default-desc (name (:function-arguments-indentation defaults))
+    :parse-fn keyword
+    :validate [#{:community :cursive :zprint}
+               "Must be one of community, cursive, or zprint"]
+    :id :function-arguments-indentation]])
 
 (defn- abort [& msg]
   (binding [*out* *err*]


### PR DESCRIPTION
Closes #323

Updated approach:

Adds a new config option `:function-arguments-indentation` with 3 possible values:
1. `:community` - the default, and same as current behaviour. Follows the [community style recommendation](https://guide.clojure.style/#one-space-indent) to indent function/macro arguments by a single space when there are no arguments on the same line as the function name.
2. `:cursive` copies Cursive's behaviour when it has "one space list indent" disabled (which is the default). Indents lists by 2 spaces when there is only one element on the first line, unless the first element (not counting metadata) is a data structure literal.
3. `:zprint` copies zprint's default behaviour. Uses two space indentation if a list starts with a symbol or a keyword and has no arguments on the same line as that symbol/keyword.

Original approach:

> Adds two new config options:
> 1. `:one-space-list-indent?` - whether cljfmt should follow the community style guide's rule to indent function arguments by one space (true) or use two spaces (false). Defaults to true
> 2. `:one-space-list-indent-tags` - Only has an effect if `:one-space-list-indent?` is false. For lists that aren't plain function calls, we sometimes want to use one space indentation. A good example is multi-arity functions, which both Cursive and zprint indent by one space even when two space indentation is enabled. For most other types of elements, Cursive and zprint disagree, so this config makes cljfmt flexible enough to match either of them. Defaults to Cursive style, which is that any list starting with a data structure has one space indent (and if there is a meta literal, it checks the type of element the meta is applied to). The tests also show how to match zprint style.
> 
> I've added tests and documented both in the README, and added a CLI flag for the first one. I don't think it's worth trying to make a CLI flag for the latter but happy to be told otherwise. I've also tried using this on a large codebase formatted by IntelliJ to check for discrepancies.
> 
> I'm not sure if this config approach is necessarily the way you want to go with it, e.g. perhaps you want to group both options under a single key. Feedback is welcome :)