### PR TITLE
feat: clean up after a successful install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,3 +39,5 @@ echo "Done!"
 
 sudo tar -xzf /tmp/cljfmt.tar.gz -C /usr/local/bin
 echo "Extracted cljfmt into /usr/local/bin"
+
+rm /tmp/cljfmt.tar.gz


### PR DESCRIPTION
With this change we would remove the unnecessary tarball after a successful install. It is really useful in Docker build where we want to keep the image on a bare minimum.

clj-kondo has a similar step in their install scripts to clean up the leftovers:

https://github.com/clj-kondo/clj-kondo/blob/master/script/install-clj-kondo