### PR TITLE
Add note about :file-pattern in edn config

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,9 @@ In order to load the standard configuration file from Leiningen, add the
 
 * `:file-pattern` -
   a regular expression to decide which files to scan. Defaults to
-  `#”\.clj[csx]?$”`.
+  `#"\.clj[csx]?$"`.
+  - When config is defined in edn file, you need to use `#re` tag and string
+    convertable to regex pattern, e.g. `:file-pattern #re "\\.clj[csx]?$"`.
 
 * `:parallel?` -
   true if cljfmt should process files in parallel. Defaults to false.


### PR DESCRIPTION
I wanted to add .edn and .bb files to be formatted by cljfmt and it wasn't clear to me immediately what why I can't use the regex expression in edn. Only after reading the code I found the :re tag. 
This short note can help other facing the same surprise. 