### PR TITLE
Feature: reporting fn to allow more ergonomic use as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ project file. See the [configuration][] section for more details.
 
 ### Library
 
-cljfmt can be run as a library that formats a string of Clojure code.
+cljfmt can be run as a library that formats a string of Clojure code or
+recursively checks / fixes paths like the CLI tool.
 First, add the dependency:
 
 ```edn
@@ -143,6 +144,8 @@ First, add the dependency:
 
 Then use the library:
 
+#### Checking strings of code:
+
 ```clojure
 (require '[cljfmt.core :as fmt])
 
@@ -150,13 +153,35 @@ Then use the library:
 ;; => "(defn sum [x y]\n  (+ x y))"
 ```
 
-To use load the configuration for the current directory:
+To load the configuration for the current directory:
 
 ```clojure
 (require '[cljfmt.config :as cfg])
 
 (fmt/reformat-string "(+ x\ny)" (cfg/load-config))
 ;; => "(+ x\n   y)"
+```
+
+#### Checking / fixing paths recursively
+
+Be sure to set the report fn to the clojure one as shown below. Otherwise the
+`check` and `fix` fns will assume they're running in console mode and will
+call `System/exit`, print to stdout, etc.
+
+```clojure
+(require '[cljfmt.tool :as fmt]
+         '[cljfmt.report :as report])
+
+(fmt/check {:paths ["/path/to/check"], :report report/clojure})
+```
+
+Or to recursively fix paths:
+
+```clojure
+(require '[cljfmt.tool :as fmt]
+         '[cljfmt.report :as report])
+
+(fmt/fix {:paths ["/path/to/fix"], :report report/clojure})
 ```
 
 ### Editor Integration

--- a/cljfmt/src/cljfmt/io.clj
+++ b/cljfmt/src/cljfmt/io.clj
@@ -1,4 +1,5 @@
 (ns cljfmt.io
+  (:require [clojure.java.io :as cio])
   (:import java.io.File))
 
 (defprotocol FileEntity
@@ -35,3 +36,6 @@
     (instance? File path) path
     (= "-" path) (->StdIO *in* *out*)
     :else (File. ^String path)))
+
+(defn project-path [{:keys [project-root]} file]
+  (->> (or project-root ".") cio/file (relative-path file)))

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -2,6 +2,7 @@
   "Functionality to apply formatting to a given project."
   (:require [cljfmt.config :as config]
             [cljfmt.io :as io]
+            [cljfmt.report :as report]
             [cljfmt.tool :as tool]
             [clojure.java.io :as jio]
             [clojure.tools.cli :as cli])
@@ -113,7 +114,7 @@
                    "fix"   tool/fix-no-config
                    (abort "Unknown cljfmt command:" cmd))]
         (abort-if-files-missing paths)
-        (binding [tool/*no-output* (:quiet? options)
+        (binding [report/*no-output* (:quiet? options)
                   tool/*verbose* (:verbose? options)]
           (cmdf options))
         (when (:parallel? options)

--- a/cljfmt/src/cljfmt/report.clj
+++ b/cljfmt/src/cljfmt/report.clj
@@ -1,0 +1,97 @@
+(ns cljfmt.report
+  (:require [cljfmt.io :as io]
+            [clojure.stacktrace :as st]))
+
+(def ^:dynamic *no-output* false)
+
+(defn warn [& args]
+  (when-not *no-output*
+    (binding [*out* *err*]
+      (apply println args))))
+
+(defn- print-stack-trace [ex]
+  (when-not *no-output*
+    (binding [*out* *err*]
+      (st/print-stack-trace ex))))
+
+(defn- print-file-status [options status]
+  (let [path (io/project-path options (:file status))]
+    (when-let [ex (:exception status)]
+      (warn "Failed to format file:" path)
+      (print-stack-trace ex))
+    (when (:reformatted status)
+      (warn "Reformatted" path))
+    (when-let [diff (:diff status)]
+      (warn path "has incorrect formatting")
+      (println diff))))
+
+(def zero-counts {:okay 0, :incorrect 0, :error 0})
+
+(defn- merge-counts
+  ([]    zero-counts)
+  ([a]   a)
+  ([a b] (merge-with + a b)))
+
+(defn- print-final-count [counts]
+  (let [error     (:error counts 0)
+        incorrect (:incorrect counts 0)]
+    (when-not (zero? error)
+      (warn error "file(s) could not be parsed for formatting"))
+    (when-not (zero? incorrect)
+      (warn incorrect "file(s) formatted incorrectly"))
+    (when (and (zero? incorrect) (zero? error))
+      (warn "All source files formatted correctly"))))
+
+(defn- exit [counts]
+  (when-not (zero? (:error counts 0))
+    (System/exit 2))
+  (when-not (zero? (:incorrect counts 0))
+    (System/exit 1)))
+
+(defmulti console (fn [event _context _data] event))
+
+(defmethod console :check/initial [_ context _] context)
+
+(defmethod console :check/file [_ context data]
+  (print-file-status context data)
+  (update context :results merge-counts (:counts data)))
+
+(defmethod console :check/summary [_ summary _]
+  (let [counts (:results summary)]
+    (print-final-count counts)
+    (exit counts)))
+
+(defmethod console :fix/initial [_ context _] context)
+
+(defmethod console :fix/file [_ context data]
+  (print-file-status context data)
+  (update context :results conj data))
+
+(defmethod console :fix/summary [_ context _] context)
+
+(defn- merge-statuses [results {:keys [file diff exception counts]}]
+  (let [path (some-> file .getPath)]
+    (-> results
+        (update :counts merge-counts counts)
+        (cond-> (and path (> (:incorrect counts) 1))
+          (assoc-in [:incorrect-files path] {}))
+        (cond-> (and path diff)
+          (assoc-in [:incorrect-files path :diff] diff))
+        (cond-> (and path exception)
+          (assoc-in [:errored-files path :exception] exception)))))
+
+(defmulti clojure (fn [event _context _data] event))
+
+(defmethod clojure :check/initial [_ context _] context)
+
+(defmethod clojure :check/file [_ context data]
+  (update context :results #(merge-statuses %1 %2) data))
+
+(defmethod clojure :check/summary [_ context _] context)
+
+(defmethod clojure :fix/initial [_ context _] context)
+
+(defmethod clojure :fix/file [_ context data]
+  (update context :results conj data))
+
+(defmethod clojure :fix/summary [_ summary _] summary)


### PR DESCRIPTION
This is a follow-up to #333 with the implementation outlined by @weavejester over there.

I think the main decision I made in here was the name and signature of the "library entry point" fns. I went with `check-paths` and `fix-paths` that take a paths collection as a first arg and then an optional options map. I did this b/c the primary purpose of this refactor was to create library-friendly entry points that check / fix paths like the CLI tool entry points do but w/o doing things like printing to stdout or exiting the whole process.

But I don't have strong opinions about any of that, so let me know if you'd like to see any changes there or anywhere else.