### PR TITLE
Fix #45: Thread first changes the indentation of the inner forms

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -692,7 +692,39 @@
          ["#:clj {:a :b"
           ":c :d}"]
          ["#:clj {:a :b"
-          "       :c :d}"]))))
+          "       :c :d}"]))) 
+
+  (testing "thread first"
+    (is (reformats-to?
+          ["(-> v"
+           "(cond->"
+           "a b"
+           "c d))"]
+          ["(-> v"
+           "    (cond->"
+           "      a b"
+           "      c d))"]))
+    (is (reformats-to?
+          ["(cond-> v"
+           "a b"
+           "c d)"]
+          ["(cond-> v"
+           "  a b"
+           "  c d)"]))
+    (is (reformats-to?
+          ["(-> v"
+           "(cond-> a b"
+           "c d))"]
+          ["(-> v"
+           "    (cond-> a b"
+           "            c d))"]))
+    (is (reformats-to?
+          ["(-> (cond-> a"
+           "odd? inc)"
+           "inc)"]
+          ["(-> (cond-> a"
+           "      odd? inc)"
+           "    inc)"]))))
 
 (deftest test-remove-multiple-non-indenting-spaces
   (let [opts {:remove-multiple-non-indenting-spaces? true}]


### PR DESCRIPTION
Here is an attempt to solve issue #45. 

The concrete issue is nesting a `->` with a `cond->` inside. Because `cond->` has indent `[[:block 1]]`, the parameters will not be indented in pairs as intended.
As mentioned in this [comment](https://github.com/weavejester/cljfmt/issues/45#issuecomment-122682926
), the indentation of an inner form within a `->` does not take the threading into account.

The proposed solution is to take the parent node into account, when determining the index of the indentation of the current node. 
The check is: 
- Is the parent form a thread-first macro? 
- Apart from this, there is the special case, which is the first argument to a thread-first, which should be indented as usual.

I just made this fix for thread-first macros in Clojure core. We could maybe do a regex instead? 

Please let me know, if I need to do any documentation or something else is missing. 
