### PR TITLE
Don't rewrite `~ @foo` to `~@foo`

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -692,7 +692,34 @@
          ["#:clj {:a :b"
           ":c :d}"]
          ["#:clj {:a :b"
-          "       :c :d}"]))))
+          "       :c :d}"])))
+  (testing "~ @ is not ~@"
+    (is (reformats-to?
+         ["~ @foo"]
+         ["~ @foo"]))
+    (is (reformats-to?
+         ["~(deref foo)"]
+         ["~(deref foo)"]))
+    (is (reformats-to?
+         ["~(clojure.core/deref foo)"]
+         ["~(clojure.core/deref foo)"]))
+    (is (reformats-to?
+         ["~ @foo"]
+         ["~ @foo"]))
+    (is (reformats-to?
+         ["~     @foo"]
+         ["~     @foo"]))
+    (is (reformats-to?
+         ["~\n@foo"]
+         ["~"
+          " @foo"]))
+    (is (reformats-to?
+         ["~;;comment\n@foo"]
+         ["~;;comment"
+          " @foo"]))
+    (is (reformats-to?
+         ["~#_a@foo"]
+         ["~#_a @foo"]))))
 
 (deftest test-remove-multiple-non-indenting-spaces
   (let [opts {:remove-multiple-non-indenting-spaces? true}]
@@ -1568,7 +1595,9 @@
                "(~@foo"
                "bar)"
                "(#:foo{:bar 1}"
-               "baz)"]]
+               "baz)"
+               "(~ @foo"
+               "bar)"]]
     (testing ":cursive style uses 2 spaces unless starting with a collection"
       (is (reformats-to?
            input
@@ -1627,7 +1656,9 @@
             "(~@foo"
             "  bar)"
             "(#:foo{:bar 1}"
-            "  baz)"]
+            "  baz)"
+            "(~ @foo"
+            "  bar)"]
            {:function-arguments-indentation :cursive})))
     (testing ":zprint uses 2 spaces if starting with a symbol, keyword, or list"
       (is (reformats-to?
@@ -1687,5 +1718,7 @@
             "(~@foo"
             " bar)"
             "(#:foo{:bar 1}"
-            " baz)"]
+            " baz)"
+            "(~ @foo"
+            " bar)"]
            {:function-arguments-indentation :zprint})))))


### PR DESCRIPTION
The problem is `~ @foo` is being reformatted to `~@foo`, a different expression. `~,@foo` is used as the canonical form because it seems to have more emphasis and stability than `~ @foo` (just by my taste, lmk).

This decision has knock-on effects if there are are other forms between `~` and `@` which are demonstrated in the tests.

The implementation uses `transform` twice, but it should ideally just be one tree pass. Please let me know if there's a preferred way to do this.