### PR TITLE
Ignore metadata in front of first symbol when looking for matching rules

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -243,7 +243,8 @@
        (some-> zloc z/down ns-token?)))
 
 (defn- token-value [zloc]
-  (when (token? zloc) (z/sexpr zloc)))
+  (let [zloc (skip-meta zloc)]
+    (when (token? zloc) (z/sexpr zloc))))
 
 (defn- reader-conditional? [zloc]
   (and (reader-macro? zloc) (#{"?" "?@"} (-> zloc z/down token-value str))))

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -475,7 +475,19 @@
           ":foo)"]
          ["(def ^:private foo"
           "  :foo)"])
-        "hanging metadata and name on def does not hang subsequent indentation"))
+        "hanging metadata and name on def does not hang subsequent indentation")
+
+    (testing "metadata on the first symbol in a list should be ignored when looking for matching indentation rules"
+      (is (reformats-to?
+           ["(^:amazing fn [x y]"
+            "(+ x y))"]
+           ["(^:amazing fn [x y]"
+            "  (+ x y))"]))
+      (is (reformats-to?
+           ["(^{:amazing true} fn [x y]"
+            "(+ x y))"]
+           ["(^{:amazing true} fn [x y]"
+            "  (+ x y))"]))))
 
   (testing "fuzzy matches"
     (is (reformats-to?


### PR DESCRIPTION
I could not get things like 

```clj
(^:once fn* [x y]
  (+ x y))
```

to format correctly despite having custom rules for `fn*`; after digging into things a bit I realized this gets parsed to a metadata node wrapping `fn*` and `token-value` doesn't work correctly in this case. Changed `token-value` to unwrap metadata nodes in this case which means the correct rule is now found and things indent according to the appropriate rule