### PR TITLE
Support specifying :default spec in custom indentation rules

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -336,6 +336,11 @@
 (defmethod indenter-fn :block [sym context [_ idx]]
   (fn [zloc] (block-indent zloc sym idx context)))
 
+(defmethod indenter-fn :default [sym context [_]]
+  (fn [zloc]
+    (when (form-matches-key? zloc sym context)
+      (list-indent zloc context))))
+
 (defn- make-indenter [[key opts] context]
   (apply some-fn (map (partial indenter-fn key context) opts)))
 

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -1248,6 +1248,14 @@
        ["{:one two #_comment"
         " :three four}"]
        {:split-keypairs-over-multiple-lines? true}))
+  (is (reformats-to?
+       ["(with-timezone (java.time.OffsetDateTime.)"
+        "\"US/Pacific\")"]
+       ["(with-timezone (java.time.OffsetDateTime.)"
+        "               \"US/Pacific\")"]
+       {:indents {#"^with-"      [[:inner 0]]
+                  'with-timezone [[:default]]}})
+      "Should be able to override fuzzy indent rules for with- and explicitly specify :default indentation")
   #?(:clj
      (is (reformats-to?
           ["(ns foo.bar"


### PR DESCRIPTION
Sometimes the default fuzzy rule for `^with-` of `[[:inner 0]]` is inappropriate, for example if you had a function like

```clj
(defn with-timezone [t zone]
  ...)
 
;;; this is a regular function and should follow `:default` list indentation rules
(with-timezone (java.time.OffsetDateTime/now)
               "US/Pacific")
```

This PR adds support for explicitly specifying `:default` formatting for a specific symbol