### PR TITLE
Fix indentation for symbols in reader conditionals

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -685,7 +685,47 @@
           ":cljs bar)"]
          ["#?@(:clj foo"
           "    :cljs bar)"])
-        "splicing syntax"))
+        "splicing syntax")
+    (testing "symbols using reader conditionals should indent correctly"
+      (let [opts {:indents '{defprotocol          [[:block 1] [:inner 1]]
+                             potemkin/defprotocol+ [[:block 1] [:inner 1]]}}]
+        (testing "standard syntax"
+          (is (reformats-to?
+               ["(#?(:clj potemkin/defprotocol+ :cljs defprotocol) MyProtocol"
+                "  \"This is a docstring for my protocol.\""
+                "  (method [this x]"
+                "    \"This is a docstring for a protocol method.\")"
+                ")"]
+               ["(#?(:clj potemkin/defprotocol+ :cljs defprotocol) MyProtocol"
+                "  \"This is a docstring for my protocol.\""
+                "  (method [this x]"
+                "    \"This is a docstring for a protocol method.\"))"]
+               opts)
+              ":clj and :cljs"))
+        (is (reformats-to?
+             ["(#?(:clj potemkin/defprotocol+) MyProtocol"
+              "  \"This is a docstring for my protocol.\""
+              "  (method [this x]"
+              "    \"This is a docstring for a protocol method.\")"
+              ")"]
+             ["(#?(:clj potemkin/defprotocol+) MyProtocol"
+              "  \"This is a docstring for my protocol.\""
+              "  (method [this x]"
+              "    \"This is a docstring for a protocol method.\"))"]
+             opts)
+            "only :clj")
+        (is (reformats-to?
+             ["(#?(:cljs ^:wow defprotocol) MyProtocol"
+              "  \"This is a docstring for my protocol.\""
+              "  (method [this x]"
+              "    \"This is a docstring for a protocol method.\")"
+              ")"]
+             ["(#?(:cljs ^:wow defprotocol) MyProtocol"
+              "  \"This is a docstring for my protocol.\""
+              "  (method [this x]"
+              "    \"This is a docstring for a protocol method.\"))"]
+             opts)
+            "only :cljs; skip metadata in front of symbol"))))
 
   (testing "namespaced maps"
     (is (reformats-to?


### PR DESCRIPTION
Things like

```clj
(#?(:clj potemkin.core/defprotocol+ :cljs defprotocol) MyProtocol
  ...)
```

were not indenting correctly despite having indentation specs defined for both `potemkin.core/defprotocol+` and `defprotocol`. 

This PR reworks `form-symbol` a little bit to return the first symbol it finds when it encounters `#?` forms -- in this case, `potemkin.core/defprotocol+` (meaning the form above will be formatted using that spec)