### PR TITLE
Fix nested :inner specs

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -173,7 +173,40 @@
          ["(defrecord Foo [x]"
           "  Closeable"
           "  (close [_]"
-          "    (prn x)))"])))
+          "    (prn x)))"]))
+    (testing "nested rules like [:inner 1] (#349)"
+      (is (reformats-to?
+           ["(ns my.namespace)"
+            ""
+            "(defprotocol MyProtocol"
+            "MyClass"
+            "(with-x [this x]"
+            "\"with-x is a method\"))"
+            ""
+            "(extend-protocol MyProtocol"
+            "MyClass"
+            "(with-x [this x]"
+            "(+ this x)))"
+            ""
+            "(defn x [x]"
+            "(with-x x "
+            "1))"]
+           ["(ns my.namespace)"
+            ""
+            "(defprotocol MyProtocol"
+            "  MyClass"
+            "  (with-x [this x]"
+            "    \"with-x is a method\"))"
+            ""
+            "(extend-protocol MyProtocol"
+            "  MyClass"
+            "  (with-x [this x]"
+            "    (+ this x)))"
+            ""
+            "(defn x [x]"
+            "  (with-x x"
+            "          1))"]
+           {:extra-indents '{my.namespace/with-x [[:block 0]]}}))))
 
   (testing "data structure indentation"
     (is (reformats-to?


### PR DESCRIPTION
Fixes #349

After spending a few hours trying to figure out the best way to solve this problem without changing too much stuff I decided to changed the `indent` order code as follows:

- specs with multiple parts like `[[:block 1] [:inner 1]]` now get compiled to separate indenters for each part of the spec e.g. one for `[:block 1]` and one for `[:inner 1]`
- `:inner` specs with depth greater than zero are sorted preferentially with deeper depths sorted first. 

Previously in #349 the `sorted-indents` we see 

https://github.com/weavejester/cljfmt/blob/d84bd41b08e3e13662c328dd1345e930d6fd6001/cljfmt/src/cljfmt/core.cljc#L384

would have looked like 

```clj
[[my.namespace/with-x [[:block 0]]]
 [extend-protocol [[:block 1] [:inner 1]]]
```

This PR changes them so they now look like

```clj
[[extend-protocol [[:inner 1]]
 [my.namespace/with-x [[:block 0]]]
 [extend-protocol [[:block 1]]]
```

This ensures nested `:inner` indenters take precedence over general top-level indenters and `defprotocol`/`extend-protocol`/etc. are applied in a sane way.