### PR TITLE
Fix formatting when requires have metadata

### DIFF
--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -257,6 +257,33 @@
          {:indents {'thing.core/defn [[:inner 0]]}
           #?@(:cljs [:alias-map {"t" "thing.core"}])})
         "applies custom indentation to namespaced defn")
+    (testing "handles metadata on or comments before forms inside ns :require list"
+      (doseq [ignore-str [""
+                          "^{:clj-kondo/ignore [:discouraged-namespace]} "
+                          "^:clj-kondo/ignore "
+                          "^{some-symbol another-symbol} "
+                          "#_{:clj-kondo/ignore [:discouraged-namespace]} "
+                          "#_:clj-kondo/ignore "
+                          "^tag "
+                          "#_old-thing "]
+              ns-vec-str [(str ignore-str "[thing.core :as t]")
+                          (str ignore-str "[thing [core :as t]]")
+                          (str ignore-str "(thing [core :as t])")
+                          (str "[" ignore-str "thing.core :as t]")
+                          (str ignore-str " [" ignore-str "thing.core :as t]")]
+              :let [ns-str (str "(ns example (:require " ns-vec-str "))")]]
+        (testing ns-str
+          (is (reformats-to?
+               [ns-str
+                ""
+                "(t/defn foo [x]"
+                "(+ x 1))"]
+               [ns-str
+                ""
+                "(t/defn foo [x]"
+                "  (+ x 1))"]
+               {:indents {'ns [[:block 1]], 'thing.core/defn [[:inner 0]]}
+                #?@(:cljs [:alias-map {"t" "thing.core"}])})))))
     (is (reformats-to?
          ["(comment)"
           "(ns thing.core)"


### PR DESCRIPTION
Fixes #351

While working on this I tried to think of all the possible weird edge cases I could and found that it also broke in a few even weirder situations e.g. if you did something like put  metadata on or comments before the `x` in `[x :as y]` itself. I added a pretty comprehensive test makes sure things work as expected no matter what shenanigans you're up to in your `ns` form. 