### PR TITLE
Optionally indent "code-fragment comments" according to the Clojure Style Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ In order to load the standard configuration file from Leiningen, add the
   the same as `:indents`, except that this will **append** to the
   default indents.
 
+* `:indent-line-comments?` -
+  true if cljfmt should align whole-line `;;` comments with the code.
+  Defaults to false.
+
 * `:alias-map` -
   a map of namespace alias strings to fully qualified namespace
   names. This option is unnecessary in most cases, because cljfmt

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -32,6 +32,9 @@
    [nil "--[no-]indentation"
     :default (:indentation? defaults)
     :id :indentation?]
+   [nil "--[no-]indent-line-comments"
+    :default (:indent-line-comments? defaults)
+    :id :indent-line-comments?]
    [nil "--[no-]remove-multiple-non-indenting-spaces"
     :default (:remove-multiple-non-indenting-spaces? defaults)
     :id :remove-multiple-non-indenting-spaces?]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -1845,3 +1845,156 @@
 
 (deftest test-clojure-12-syntax
   (is (reformats-to? ["^Long/1 a"] ["^Long/1 a"])))
+
+(deftest test-indenting-comments
+  (testing "whole-line comments"
+    (testing "whole-line flush-left comments"
+      (testing "whole-line margin flush-left ; comments"
+        (is (reformats-to?
+             ["(when 42"
+              "; leave me alone"
+              ")"]
+             ["(when 42"
+              "; leave me alone"
+              "  )"]
+             {:indent-line-comments? true}))
+        (is (reformats-to?
+             ["(when 42"
+              ";"
+              ")"]
+             ["(when 42"
+              ";"
+              "  )"]
+             {:indent-line-comments? true})))
+      (testing "whole-line line flush-left ;; comments"
+        (is (reformats-to?
+             ["(when 42"
+              ";; answer"
+              ")"]
+             ["(when 42"
+              "  ;; answer"
+              "  )"]
+             {:indent-line-comments? true}))
+        (is (reformats-to?
+             ["(when 42"
+              ";;"
+              ")"]
+             ["(when 42"
+              "  ;;"
+              "  )"]
+             {:indent-line-comments? true})))
+      (testing "whole-line heading flush-left ;;; comments"
+        (is (reformats-to?
+             ["(when 42"
+              ";;; heading"
+              ")"]
+             ["(when 42"
+              ";;; heading"
+              "  )"]
+             {:indent-line-comments? true}))
+        (is (reformats-to?
+             ["(when 42"
+              ";;;"
+              ")"]
+             ["(when 42"
+              ";;;"
+              "  )"]
+             {:indent-line-comments? true}))))
+    (testing "whole-line pre-indented comments"
+      (testing "whole-line margin pre-indented ; comments"
+        (is (reformats-to?
+             ["(when 42"
+              "     ; leave me alone"
+              ")"]
+             ["(when 42"
+              "     ; leave me alone"
+              "  )"]
+             {:indent-line-comments? true}))
+        (is (reformats-to?
+             ["(when 42"
+              "     ;"
+              ")"]
+             ["(when 42"
+              "     ;"
+              "  )"]
+             {:indent-line-comments? true})))
+      (testing "whole-line line pre-indented ;; comments"
+        (is (reformats-to?
+             ["(when 42"
+              "     ;; answer"
+              ")"]
+             ["(when 42"
+              "  ;; answer"
+              "  )"]
+             {:indent-line-comments? true}))
+        (is (reformats-to?
+             ["(when 42"
+              "     ;;"
+              ")"]
+             ["(when 42"
+              "  ;;"
+              "  )"]
+             {:indent-line-comments? true})))
+      (testing "whole-line heading pre-indented ;;; comments"
+        (is (reformats-to?
+             ["(when 42"
+              "     ;;; heading"
+              ")"]
+             ["(when 42"
+              "     ;;; heading"
+              "  )"]
+             {:indent-line-comments? true}))
+        (is (reformats-to?
+             ["(when 42"
+              "     ;;;"
+              ")"]
+             ["(when 42"
+              "     ;;;"
+              "  )"]
+             {:indent-line-comments? true})))))
+  (testing "after-code comments"
+    (testing "after-code margin ; comments"
+      (is (reformats-to?
+           ["(when 42  ; leave me alone"
+            "     :a"
+            ")"]
+           ["(when 42  ; leave me alone"
+            "  :a)"]
+           {:indent-line-comments? true}))
+      (is (reformats-to?
+           ["(when 42  ;"
+            "     :a"
+            ")"]
+           ["(when 42  ;"
+            "  :a)"]
+           {:indent-line-comments? true})))
+    (testing "after-code line ;; comments"
+      (is (reformats-to?
+           ["(when 42  ;; leave me alone"
+            "     :a"
+            ")"]
+           ["(when 42  ;; leave me alone"
+            "  :a)"]
+           {:indent-line-comments? true}))
+      (is (reformats-to?
+           ["(when 42  ;;"
+            "     :a"
+            ")"]
+           ["(when 42  ;;"
+            "  :a)"]
+           {:indent-line-comments? true})))
+    (testing "after-code heading ;;; comments"
+      (is (reformats-to?
+           ["(when 42  ;;; leave me alone"
+            "     :a"
+            ")"]
+           ["(when 42  ;;; leave me alone"
+            "  :a)"]
+           {:indent-line-comments? true}))
+      (is (reformats-to?
+           ["(when 42  ;;;"
+            "     :a"
+            ")"]
+           ["(when 42  ;;;"
+            "  :a)"]
+           {:indent-line-comments? true})))))


### PR DESCRIPTION
Issue #112 asked about aligning ";;" comments like code and attracted some discussion. Issue #222 is a more focused request for indenting ";;" comments. The Clojure Style Guide says, "Write comments on a particular fragment of code before that fragment and aligned with it, using two semicolons".  In cljfmt's source code, "core.cljc" appears to follow this convention.

This PR indents code-fragment comments, optionally, when the new option `:indent-code-fragment-comments?` is true. (The name follows the Clojure Style Guide.) This PR also adds a corresponding command-line option, a mention in the README under "Formatting Options", and a test.

The option to indent code-fragment comments is *false by default*, as suggested by weavejester in a comment on #222.