### PR TITLE
Use strings for `:alias-map` in indent docs

### DIFF
--- a/docs/INDENTS.md
+++ b/docs/INDENTS.md
@@ -42,7 +42,7 @@ example:
 
 ```clojure
 {:extra-indents {com.example/foo [[:inner 0]]}
- :alias-map {ex com.example}}
+ :alias-map {"ex" "com.example"}}
 ```
 
 This rule would match both `com.example/foo` and `ex/foo`.


### PR DESCRIPTION
Since only strings are supported for `:alias-map` (for now), the example should show strings.

As per https://github.com/weavejester/cljfmt/issues/363#issuecomment-2789383831