### PR TITLE
Add :align-binding-columns? option

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,25 @@ In order to load the standard configuration file from Leiningen, add the
   symbols or strings. This option is unnecessary in most cases, because
   cljfmt will parse the `ns` declaration in each file. See [INDENTS.md][].
 
+* `:binding-forms` -
+  a map of symbols to indexes that tell cljfmt where to expect binding
+  forms. For example, `{'let #{0}}` indicates that `let` has a binding
+  vector found at the first argument (index 0). This will **replace**
+  the default binding forms. Used by `:align-binding-columns?`.
+
 * `:align-map-columns?` -
   true if cljfmt should align the keys and values of maps such that they
   line up in columns. Defaults to false. **Experimental.**
+
+* `:align-binding-columns?` -
+  true if cljfmt should align the symbols and values in binding forms
+  (such as `let`) so that they line up in columns. The binding forms
+  are defined via the `:binding-forms` and `:extra-binding-forms`
+  options. Defaults to false. **Experimental.**
+
+* `:extra-binding-forms` -
+  the same as `:binding-forms`, except that this will **append** to the
+  default binding forms.
 
 * `:extra-indents` -
   the same as `:indents`, except that this will **append** to the

--- a/cljfmt/resources/cljfmt/binding_forms/clojure.clj
+++ b/cljfmt/resources/cljfmt/binding_forms/clojure.clj
@@ -1,0 +1,9 @@
+{let   #{0}
+ doseq #{0}
+ go-loop #{0}
+ binding #{0}
+ with-open #{0}
+ loop #{0}
+ for #{0}
+ with-local-vars #{0}
+ with-redefs #{0}}

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -2191,3 +2191,78 @@
          ["{:x      1   ; a comment"
           " :longer 2}"]
          {:align-map-columns? true}))))
+
+(deftest test-align-binding-columns
+  (testing "basic alignment"
+    (is (reformats-to?
+         ["(let [x 1]"
+          "  x)"]
+         ["(let [x 1]"
+          "  x)"]
+         {:align-binding-columns? true}))
+    (is (reformats-to?
+         ["(let [longer 1"
+          "      x 2]"
+          "  (+ x longer))"]
+         ["(let [longer 1"
+          "      x      2]"
+          "  (+ x longer))"]
+         {:align-binding-columns? true}))
+    (is (reformats-to?
+         ["(def foo [aaa bb"
+          "          c d]"
+          "  (let [longer 1"
+          "        x 2]"
+          "    (+ x longer)))"]
+         ["(def foo [aaa bb"
+          "          c d]"
+          "  (let [longer 1"
+          "        x      2]"
+          "    (+ x longer)))"]
+         {:align-binding-columns? true}))
+    (is (reformats-to?
+         ["(for [x [0 1 2 3 4 5]"
+          "      :let [y (* x 3)]"
+          "      :when (even? y)]"
+          "  y)"]
+         ["(for [x     [0 1 2 3 4 5]"
+          "      :let  [y (* x 3)]"
+          "      :when (even? y)]"
+          "  y)"]
+         {:align-binding-columns? true})))
+  (testing "alignment with maps"
+    (is (reformats-to?
+         ["(let [longer {:x 1"
+          "              :wider 2}"
+          "      y 3]"
+          "  (+ x longer))"]
+         ["(let [longer {:x     1"
+          "              :wider 2}"
+          "      y      3]"
+          "  (+ x longer))"]
+         {:align-binding-columns? true
+          :align-map-columns?     true}))
+    (is (reformats-to?
+         ["{:x (let [x 1"
+          "          wider 2]"
+          "      (+ x 1))"
+          " :longer 3}"]
+         ["{:x      (let [x     1"
+          "               wider 2]"
+          "           (+ x 1))"
+          " :longer 3}"]
+         {:align-binding-columns? true
+          :align-map-columns?     true})))
+  (testing "nested alignment"
+    (is (reformats-to?
+         ["(let [longer (let [x 1"
+          "                   yyy 2]"
+          "               (+ x yyy))"
+          "      y 3]"
+          "  (+ x longer))"]
+         ["(let [longer (let [x   1"
+          "                   yyy 2]"
+          "               (+ x yyy))"
+          "      y      3]"
+          "  (+ x longer))"]
+         {:align-binding-columns? true}))))


### PR DESCRIPTION
Adds the :align-binding-columns? option to allow alignment of binding forms like `let`.

```clojure
;; before alignment
(let [x 1
      longer 2]
  (+ x longer))

;; after alignment
(let [x      1
      longer 2]
  (+ x longer))
```

These forms are configured via the `:binding-forms` option.