### PR TITLE
Fix #378: Add :blank-lines-separate-alignment? option to separate alignment groups 

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ In order to load the standard configuration file from Leiningen, add the
   padding in other lines. Only applies when `:align-form-columns?` or  
   `:align-map-columns?` is true. Defaults to false. **Experimental.**  
 
+* `blank-lines-separate-alignment` -
+  true if cljfmt should treat blank lines as separators when
+  aligning columns. When enabled, alignment groups are separated by
+  blank lines, allowing independent alignment within each group.
+  Defaults to false. **Experimental.**
+
 * `:blank-line-forms` - map of symbols that tell cljfmt which forms are allowed
   to have blank lines inside of them. The value may be either `:all`, which
   means blank lines are allowed between all elements in the form, e.g. `{'cond

--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -374,6 +374,7 @@
    :align-single-column-lines?            false
    :aligned-forms                         default-aligned-forms
    :blank-line-forms                      blank-line-forms
+   :blank-lines-separate-alignment?       false
    :extra-aligned-forms                   {}
    :extra-blank-line-forms                {}
    :extra-indents                         {}
@@ -627,16 +628,6 @@
   (and (line-break? (skip-whitespace-and-commas (z/right* zloc) z/right*))
        (line-break? (skip-whitespace-and-commas (z/left* zloc) z/left*))))
 
-(defn- max-column-end-position [zloc col align-single-column-lines?]
-  (reduce-columns zloc
-                  (fn [zloc c max-pos]
-                    (if (and (= c col)
-                             (or align-single-column-lines?
-                                 (not (single-column-line? zloc))))
-                      (max max-pos (node-end-position zloc))
-                      max-pos))
-                  0))
-
 (defn- node-str-length [zloc]
   (-> zloc z/node n/string count))
 
@@ -681,24 +672,54 @@
           zloc))
       zloc)))
 
-(defn- align-one-column [zloc col align-single-column-lines?]
+(defn- end-of-column-group? [zloc]
+  (line-break? zloc) (> (count-newlines zloc) 1))
+
+(defn- find-start-of-column-group [zloc]
+  (z/skip z/left* #(some-> % z/left* end-of-column-group? not) zloc))
+
+(defn- reduce-column-group [zloc f init]
+  (loop [zloc (find-start-of-column-group zloc)
+         col 0, acc init]
+    (let [zloc (skip-whitespace-and-commas zloc z/right*)]
+      (if (or (nil? zloc) (end-of-column-group? zloc))
+        acc
+        (if (line-break? zloc)
+          (recur (z/right* zloc) 0 acc)
+          (recur (z/right* zloc) (inc col) (f zloc col acc)))))))
+
+(defn- column-start-position [zloc col opts]
+  (let [reduce-fn (if (:blank-lines-separate-alignment? opts)
+                    reduce-column-group
+                    reduce-columns)
+        maximizer (fn [zloc c max-pos]
+                    (if (and (= c (dec col))
+                             (or (:align-single-column-lines? opts)
+                                 (not (single-column-line? zloc))))
+                      (max max-pos (node-end-position zloc))
+                      max-pos))]
+    (inc (reduce-fn zloc maximizer 0))))
+
+(defn- align-one-column
+  [zloc col {:keys [blank-lines-separate-alignment?] :as opts}]
   (if-some [zloc (z/down zloc)]
-    (let [start-position (inc (max-column-end-position
-                               zloc (dec col) align-single-column-lines?))]
-      (z/up (edit-column zloc col #(pad-to-position % start-position))))
+    (let [start-position-fn (if blank-lines-separate-alignment?
+                              #(column-start-position % col opts)
+                              (constantly
+                               (column-start-position zloc col opts)))]
+      (z/up (edit-column zloc col #(pad-to-position % (start-position-fn %)))))
     zloc))
 
-(defn- align-columns [zloc align-single-column-lines?]
-  (reduce #(align-one-column %1 %2 align-single-column-lines?)
+(defn- align-columns [zloc opts]
+  (reduce #(align-one-column %1 %2 opts)
           zloc
           (-> zloc z/down count-columns range rest)))
 
 (defn align-map-columns
   ([form]
    (align-map-columns form default-options))
-  ([form {:keys [align-single-column-lines?]}]
-   (let [align #(align-columns % align-single-column-lines?)]
-     (transform form edit-all z/map? align))))
+  ([form opts]
+   (transform form edit-all z/map? #(align-columns % opts))))
 
 (defn- matching-form-index? [zloc [k indexes] context]
   (if (= :all indexes)
@@ -715,19 +736,18 @@
 (defn align-form-columns
   ([form aligned-forms alias-map]
    (align-form-columns form aligned-forms alias-map default-options))
-  ([form aligned-forms alias-map {:keys [align-single-column-lines?]}]
+  ([form aligned-forms alias-map opts]
    (let [ns-name  (find-namespace (z/of-node form))
          context  {:alias-map alias-map, :ns-name ns-name}
-         aligned? #(matching-form? % aligned-forms context)
-         align    #(align-columns % align-single-column-lines?)]
-     (transform form edit-all aligned? align))))
+         aligned? #(matching-form? % aligned-forms context)]
+     (transform form edit-all aligned? #(align-columns % opts)))))
 
 (defn realign-form
   "Realign a rewrite-clj form such that the columns line up into columns."
   ([form]
    (realign-form form default-options))
-  ([form {:keys [align-single-column-lines?]}]
-   (-> form z/of-node (align-columns align-single-column-lines?) z/root)))
+  ([form opts]
+   (-> form z/of-node (align-columns opts) z/root)))
 
 (defn- unalign-from-space [zloc]
   (pad-node (z/right* zloc) (- 1 (node-str-length zloc))))

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -23,6 +23,9 @@
    [nil "--[no-]align-map-columns"
     :default (:align-map-columns? defaults)
     :id :align-map-columns?]
+   [nil "--[no-]blank-lines-separate-alignment"
+    :default (:blank-lines-separate-alignment? defaults)
+    :id :blank-lines-separate-alignment?]
    [nil "--[no-]ansi"
     :default (:ansi? defaults)
     :id :ansi?]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -2659,6 +2659,236 @@
           "  (+ a c))"]
          {:align-form-columns? true}))))
 
+(deftest test-blank-lines-separate-alignment
+  (testing "let bindings with blank line separation"
+    (is (reformats-to?
+         ["(let [short-var                                        true"
+          "      much-longer-var-name-that-should-force-alignment true"
+          ""
+          "      some-map                                         {:a            1"
+          "                                                        :alphabetical 2}]"
+          "  ...)"]
+         ["(let [short-var                                        true"
+          "      much-longer-var-name-that-should-force-alignment true"
+          ""
+          "      some-map {:a            1"
+          "                :alphabetical 2}]"
+          "  ...)"]
+         {:align-form-columns? true
+          :blank-lines-separate-alignment? true})))
+
+  (testing "maps with blank line separation"
+    (is (reformats-to?
+         ["{:x 1"
+          " :longer 2"
+          ""
+          " :another-key 3"
+          " :y 4}"]
+         ["{:x      1"
+          " :longer 2"
+          ""
+          " :another-key 3"
+          " :y           4}"]
+         {:align-map-columns? true
+          :blank-lines-separate-alignment? true})))
+
+  (testing "single group with blank-lines-separate-alignment? true"
+    (is (reformats-to?
+         ["(let [a 1"
+          "      bb 2"
+          "      ccc 3]"
+          "  (+ a bb ccc))"]
+         ["(let [a   1"
+          "      bb  2"
+          "      ccc 3]"
+          "  (+ a bb ccc))"]
+         {:align-form-columns? true
+          :blank-lines-separate-alignment? true}))
+    (is (reformats-to?
+         ["{:a 1"
+          " :bb 2"
+          " :ccc 3}"]
+         ["{:a   1"
+          " :bb  2"
+          " :ccc 3}"]
+         {:align-map-columns? true
+          :blank-lines-separate-alignment? true}))))
+
+(deftest test-alignment-with-comments
+  (testing "comments between map entries should not affect alignment"
+    (is (reformats-to?
+         ["{:key1 \"value1\""
+          " ;; This is a comment"
+          " :key2 \"value2\""
+          " ;; Another comment"
+          " :longer-key \"value3\"}"]
+         ["{:key1       \"value1\""
+          " ;; This is a comment"
+          " :key2       \"value2\""
+          " ;; Another comment"
+          " :longer-key \"value3\"}"]
+         {:align-map-columns? true
+          :blank-lines-separate-alignment? true
+          :align-single-column-lines? false})))
+
+  (testing "map starting with long comment should not affect alignment"
+    (is (reformats-to?
+         ["{;; This is a very long comment at the beginning of the map"
+          " :a 1"
+          " :bb 2"
+          " :ccc 3}"]
+         ["{;; This is a very long comment at the beginning of the map"
+          " :a   1"
+          " :bb  2"
+          " :ccc 3}"]
+         {:align-map-columns? true})))
+
+  (testing "comment with blank line causes alignment across entire map by default"
+    (is (reformats-to?
+         ["{:_test :ok"
+          ""
+          " ;; this is a very long comment that is too long"
+          " :align-binding-columns? true}"]
+         ["{:_test                  :ok"
+          ""
+          " ;; this is a very long comment that is too long"
+          " :align-binding-columns? true}"]
+         {:align-map-columns? true
+          :align-single-column-lines? false})))
+
+  (testing "comment with blank line does not affect alignment with option set"
+    (is (reformats-to?
+         ["{:_test :ok"
+          ""
+          " ;; comment very long that is too long"
+          " :align-binding-columns? true}"]
+         ["{:_test :ok"
+          ""
+          " ;; comment very long that is too long"
+          " :align-binding-columns? true}"]
+         {:align-map-columns? true
+          :blank-lines-separate-alignment? true}))))
+
+(deftest test-combined-blank-lines-and-single-column-alignment
+  (testing "multicolumn map with both options true"
+    (is (reformats-to?
+         ["{:a 1 :b 2"
+          " :key1"
+          " (fn [x] x)"
+          " :key2 3"
+          ""
+          " :c 4 :d 5"
+          " :longer 6}"]
+         ["{:a         1 :b 2"
+          " :key1"
+          " (fn [x] x)"
+          " :key2      3"
+          ""
+          " :c      4 :d 5" " :longer 6}"]
+         {:align-map-columns? true
+          :blank-lines-separate-alignment? true
+          :align-single-column-lines? true})))
+
+  (testing "multicolumn map with blank-lines true, single-column false"
+    (is (reformats-to?
+         ["{:short 1 :x 2"
+          " :wrapped"
+          " (fn [a b] (+ a b))"
+          " :y 3}"]
+         ["{:short 1 :x 2"
+          " :wrapped"
+          " (fn [a b] (+ a b))"
+          " :y     3}"]
+         {:align-map-columns? true
+          :blank-lines-separate-alignment? true
+          :align-single-column-lines? false})))
+
+  (testing "multicolumn map with blank-lines false, single-column true"
+    (is (reformats-to?
+         ["{:a 1 :b 2"
+          " :key1 3"
+          " :key2"
+          " (fn [x] x)"
+          ""
+          " :c 4 :d 5"
+          " :longer 6}"]
+         ["{:a         1 :b 2"
+          " :key1      3"
+          " :key2"
+          " (fn [x] x)"
+          ""
+          " :c         4 :d 5"
+          " :longer    6}"]
+         {:align-map-columns? true
+          :blank-lines-separate-alignment? false
+          :align-single-column-lines? true})))
+
+  (testing "multicolumn let bindings with both options true"
+    (is (reformats-to?
+         ["(let [a 1 b 2"
+          "      long-var 3"
+          "      wrapped"
+          "      (fn [x] (+ x 1))"
+          ""
+          "      c 4 d 5"
+          "      another 6]"
+          "  (+ a b c d))"]
+         ["(let [a                1 b 2"
+          "      long-var         3"
+          "      wrapped"
+          "      (fn [x] (+ x 1))"
+          ""
+          "      c       4 d 5"
+          "      another 6]"
+          "  (+ a b c d))"]
+         {:align-form-columns? true
+          :blank-lines-separate-alignment? true
+          :align-single-column-lines? true})))
+
+  (testing "multicolumn let bindings with blank-lines true, single-column false"
+    (is (reformats-to?
+         ["(let [a 1 b 2"
+          "      long-var 3"
+          "      wrapped"
+          "      (fn [x] (+ x 1))"
+          ""
+          "      c 4 d 5"
+          "      another 6]"
+          "  (+ a b c d))"]
+         ["(let [a        1 b 2"
+          "      long-var 3"
+          "      wrapped"
+          "      (fn [x] (+ x 1))"
+          ""
+          "      c       4 d 5"
+          "      another 6]"
+          "  (+ a b c d))"]
+         {:align-form-columns? true
+          :blank-lines-separate-alignment? true
+          :align-single-column-lines? false})))
+
+  (testing "multicolumn let bindings with blank-lines false, single-column true"
+    (is (reformats-to?
+         ["(let [a 1 b 2"
+          "      long-var 3"
+          "      wrapped"
+          "      (fn [x] (+ x 1))"
+          ""
+          "      c 4 d 5"
+          "      another 6]"
+          "  (+ a b c d))"]
+         ["(let [a                1 b 2"
+          "      long-var         3"
+          "      wrapped"
+          "      (fn [x] (+ x 1))"
+          ""
+          "      c                4 d 5"
+          "      another          6]"
+          "  (+ a b c d))"]
+         {:align-form-columns? true
+          :blank-lines-separate-alignment? false
+          :align-single-column-lines? true}))))
+
 (deftest test-realign-form
   (is (= "
 {:x   1


### PR DESCRIPTION
feat: add option to treat blank lines as alignment group separators

Introduce the :blank-lines-separate-alignment? option to control
alignment behavior in maps and aligned forms. When enabled, cljfmt
treats blank lines as boundaries for alignment groups, aligning
columns independently within each group separated by blank lines.
The CLI now supports --[no-]blank-lines-separate-alignment, and
the README documents the feature as experimental.

This allows for more granular control over column alignment,
especially in forms where logical groupings are separated by
blank lines.

Closes #378 