### PR TITLE
Add exit code reporting for :fix/summary console

### DIFF
--- a/cljfmt/src/cljfmt/report.clj
+++ b/cljfmt/src/cljfmt/report.clj
@@ -67,7 +67,10 @@
   (print-file-status context data)
   (update context :results conj data))
 
-(defmethod console :fix/summary [_ context _] context)
+(defmethod console :fix/summary [_ context _]
+  (when (some :exception (:results context))
+    (System/exit 2))
+  context)
 
 (defn- merge-statuses [results {:keys [file diff exception counts]}]
   (let [path (some-> file .getPath)]


### PR DESCRIPTION
The :fix/summary console method now counts exceptions in results and exits with an error code of 2, so downstream tools can detect when fixes fail.