### PR TITLE
Add :indent-rich-comments? option

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ In order to load the standard configuration file from Leiningen, add the
   true if cljfmt should correct the indentation of your code.
   Defaults to true.
 
+* `:indent-rich-comments?` -
+  true if cljfmt should indent the closing parenthesis of `(comment ...)`
+  forms. Defaults to true.
+
 * `:indents` -
   a map of var symbols to indentation rules, i.e. `{symbol [& rules]}`.
   See [INDENTS.md][] for a complete explanation. This will **replace**

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -44,6 +44,9 @@
    [nil "--[no-]indent-line-comments"
     :default (:indent-line-comments? defaults)
     :id :indent-line-comments?]
+   [nil "--[no-]indent-rich-comments"
+    :default (:indent-rich-comments? defaults)
+    :id :indent-rich-comments?]
    [nil "--[no-]insert-missing-whitespace"
     :default (:insert-missing-whitespace? defaults)
     :id :insert-missing-whitespace?]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -1041,6 +1041,38 @@
          ["#?@(:cljs[foo bar] :clj[baz quux])"]
          ["#?@(:cljs [foo bar] :clj [baz quux])"]))))
 
+(deftest test-indent-rich-comments
+  (testing "indent-rich-comments?"
+    (is (reformats-to?
+         ["(comment"
+          "  (range 5"
+          "         )"
+          "    (interpose '* (range 5))"
+          "  (->> (range 5) (interpose '*))"
+          "  (= *1 *2)"
+          "  )"]
+         ["(comment"
+          "  (range 5)"
+          "  (interpose '* (range 5))"
+          "  (->> (range 5) (interpose '*))"
+          "  (= *1 *2)"
+          "  )"]
+         {:indent-rich-comments? true}))
+    (is (reformats-to?
+         ["(comment"
+          "  (foo)"
+          "  )"]
+         ["(comment"
+          "  (foo))"]
+         {:indent-rich-comments? false}))
+    (is (reformats-to?
+         ["(comment"
+          "  (foo))"]
+         ["(comment"
+          "  (foo)"
+          "  )"]
+         {:indent-rich-comments? true}))))
+
 (deftest test-consecutive-blank-lines
   (is (reformats-to?
        ["(foo)"


### PR DESCRIPTION
Rich comments are often used as a scratchpad where forms are added and removed frequently. Allowing the closing parenthesis to be placed on a new line, aligned with the indentation of the block, makes these edits cleaner and keeps the diffs focused on the actual code changes.

This commit adds the :indent-rich-comments? option, which:
- Ensures a trailing newline exists in rich comments when enabled.
- Prevents the removal of this newline during whitespace cleanup.
- Aligns the closing parenthesis with the block's indentation.

Fixes #365.