### PR TITLE
Fix case-sensitive sorting in sort-ns-references

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -589,7 +589,8 @@
       (remove-node-metadata)
       (nodes-string)
       (str/replace #"[\[\]\(\)\{\}]" "")
-      (str/trim)))
+      (str/trim)
+      (str/lower-case)))
 
 (defn sort-arguments [zloc]
   (update-children zloc #(sort-node-arguments-by node-sort-string %)))

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -1877,7 +1877,17 @@
         "    ^{:x 1} b"
         "    [c]))"]
        {:sort-ns-references? true
-        :function-arguments-indentation :cursive})))
+        :function-arguments-indentation :cursive}))
+  (is (reformats-to?
+       ["(ns example"
+        "  (:require"
+        "   [com.example.ERP.service :as erp]"
+        "   [com.example.answers :as answers]))"]
+       ["(ns example"
+        "  (:require"
+        "   [com.example.answers :as answers]"
+        "   [com.example.ERP.service :as erp]))"]
+       {:sort-ns-references? true})))
 
 (deftest cursive-and-zprint-function-argument-indents-depend-on-first-element
   (let [input ["(foo"


### PR DESCRIPTION
The :sort-ns-references? option was performing case-sensitive string sorting, causing uppercase namespace references to sort before lowercase ones. This resulted in unexpected ordering like "ERP" before "answers". Modified the node-sort-string function to perform case-insensitive sorting by converting the sort string to lowercase before comparison. Added a test case to verify correct case-insensitive sorting behavior.

Fixes #388