### PR TITLE
Fix security vulnerability: prevent code execution in config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ files in the current and parent directories:
 
 The configuration file should contain a map of options.
 
+**Note:** By default, `.clj` config files are ignored because they can
+execute arbitrary code. To enable reading `.clj` config files, use the
+`--read-clj-config-files` command-line option.
+
 ### Leiningen
 
 In Leiningen, the configuration is found in on the `:cljfmt` key in the
@@ -367,6 +371,11 @@ In order to load the standard configuration file from Leiningen, add the
 
 * `:parallel?` -
   true if cljfmt should process files in parallel. Defaults to false.
+
+* `:read-clj-config-files?` -
+  true if cljfmt should read `.clj` config files. For security reasons,
+  `.clj` config files are ignored by default, as they can execute arbitrary
+  code. Set this to true to enable reading `.clj` config files. Defaults to false.
 
 * `:paths` -
   determines which files and directories to recursively search for

--- a/bb.edn
+++ b/bb.edn
@@ -11,8 +11,10 @@
         :extra-deps {eftest/eftest {:mvn/version "0.6.0"}}
         :extra-paths ["cljfmt/test"]
         :requires ([clojure.test :as t]
-                   [cljfmt.core-test])
-        :task (let [{:keys [fail error]} (t/run-tests 'cljfmt.core-test)]
+                   [cljfmt.core-test]
+                   [cljfmt.config-test])
+        :task (let [{:keys [fail error]} (t/run-tests 'cljfmt.config-test
+                                                      'cljfmt.core-test)]
                 (when (or (pos? fail)
                           (pos? error))
                   (throw (ex-info "Tests failed" {:babashka/exit 1}))))}}}

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -72,7 +72,10 @@
     :id :sort-ns-references?]
    [nil "--[no-]split-keypairs-over-multiple-lines"
     :default (:split-keypairs-over-multiple-lines? defaults)
-    :id :split-keypairs-over-multiple-lines?]])
+    :id :split-keypairs-over-multiple-lines?]
+   [nil "--[no-]read-clj-config-files"
+    :default (:read-clj-config-files? defaults)
+    :id :read-clj-config-files?]])
 
 (defn- abort [& msg]
   (binding [*out* *err*]
@@ -101,7 +104,7 @@
 (defn- find-config-file [args]
   (let [opts (cli/parse-opts args (cli-options config/default-config))]
     (or (some-> opts :options :config jio/file)
-        (config/find-config-file))))
+        (config/find-config-file "" opts))))
 
 (defn -main [& args]
   (let [config-file   (find-config-file args)

--- a/cljfmt/test/cljfmt/config_test.clj
+++ b/cljfmt/test/cljfmt/config_test.clj
@@ -1,6 +1,6 @@
 (ns cljfmt.config-test
   (:require [cljfmt.config :as config]
-            [clojure.test :refer [deftest is]]))
+            [clojure.test :refer [deftest is testing]]))
 
 (deftest test-convert-legacy-keys
   (is (= {:indents {'foo [[:inner 0]]}}
@@ -8,3 +8,47 @@
   (is (= {:extra-indents {'foo [[:inner 0]]}}
          (config/convert-legacy-keys {:legacy/merge-indents? true
                                       :indents {'foo [[:inner 0]]}}))))
+
+(deftest read-config-test
+  (testing "Ensure that reading .clj config files works for valid data"
+    (let [temp-file (java.io.File/createTempFile "test" ".clj")]
+      (spit temp-file "{:key \"value\"}")
+      (is (= {:key "value"} (config/read-config temp-file)))
+      (.delete temp-file)))
+
+  (testing "Ensure that reading .edn config files works"
+    (let [temp-file (java.io.File/createTempFile "test" ".edn")]
+      (spit temp-file "{:key \"value\"}")
+      (is (= {:key "value"} (config/read-config temp-file)))
+      (.delete temp-file))))
+
+(deftest load-config-test
+  (let [temp-dir (java.io.File/createTempFile "test" "")
+        _ (do (.delete temp-dir)
+              (.mkdir temp-dir))
+        path (.getPath temp-dir)
+        clj-file (java.io.File. temp-dir ".cljfmt.clj")
+        delete-regex-ks #(dissoc % :file-pattern :indents)
+        config (delete-regex-ks config/default-config)
+        new-config (-> config
+                       (update :remove-consecutive-blank-lines? not)
+                       delete-regex-ks)
+        config-with-read-clj (assoc new-config :read-clj-config-files? true)
+        load-config #(delete-regex-ks (config/load-config %1 %2))]
+    (testing "load-config ignores .clj config files when flag is false 
+              (default)"
+      (spit clj-file (pr-str new-config))
+      (is (= (load-config path config) config)))
+
+    (testing "load-config loads .clj config files when flag is true"
+      (spit clj-file (pr-str config-with-read-clj))
+      (is (= (load-config path config-with-read-clj)
+             config-with-read-clj)))
+
+    (testing "load-config always loads .edn config files"
+      (let [edn-file (java.io.File. temp-dir ".cljfmt.edn")]
+        (spit edn-file (pr-str new-config))
+        (is (= (load-config path new-config)
+               new-config))))
+
+    (.delete temp-dir)))


### PR DESCRIPTION
Fix security vulnerability: prevent code execution in config files
Replace read-string with edn/read-string for .clj config files to prevent
arbitrary code execution via reader macros like #=. This maintains support
for safe reader macros like #re while eliminating the security risk.

Add tests to verify that malicious reader macros throw exceptions and
valid configs still work.

Fixes https://github.com/weavejester/cljfmt/issues/391