### PR TITLE
Add refer-map support for custom indentation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,13 @@ In order to load the standard configuration file from Leiningen, add the
   symbols or strings. This option is unnecessary in most cases, because
   cljfmt will parse the `ns` declaration in each file. See [INDENTS.md][].
 
+* `:refer-map` -
+  a map of referred symbol names to fully qualified namespace names. May be
+  symbols or strings. This option is unnecessary in most cases, because
+  cljfmt will parse the `ns` declaration in each file to extract `:refer`
+  mappings. Used for indentation rules when unqualified symbols need to be
+  matched against qualified indent rules. See [INDENTS.md][].
+
 * `:aligned-forms` -
   a map of symbols to indexes that tell cljfmt where to expect forms it
   should align. For example, `{'let #{0}}` indicates that the first

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -392,6 +392,63 @@
           #?@(:cljs [:alias-map {"t" "thing.core"}])})
         "applies custom indentation to namespaced defrecord")
     (is (reformats-to?
+         ["(ns example"
+          "(:require [thing.core :refer [timed]]))"
+          ""
+          "(timed \"x\""
+          ":a"
+          ":b)"]
+         ["(ns example"
+          "    (:require [thing.core :refer [timed]]))"
+          ""
+          "(timed \"x\""
+          "  :a"
+          "  :b)"]
+         {:indents {'thing.core/timed [[:inner 0]]}
+          #?@(:cljs [:refer-map {"timed" "thing.core"}])})
+        "applies custom indentation to referred vars")
+    (is (reformats-to?
+         ["(ns example"
+          "(:require [thing.core :refer [timed another]]))"
+          ""
+          "(timed \"x\""
+          ":a"
+          ":b)"
+          ""
+          "(another \"y\""
+          ":c"
+          ":d)"]
+         ["(ns example"
+          "    (:require [thing.core :refer [timed another]]))"
+          ""
+          "(timed \"x\""
+          "  :a"
+          "  :b)"
+          ""
+          "(another \"y\""
+          "  :c"
+          "  :d)"]
+         {:indents {'thing.core/timed [[:inner 0]]
+                    'thing.core/another [[:inner 0]]}
+          #?@(:cljs [:refer-map {"timed" "thing.core", "another" "thing.core"}])})
+        "applies custom indentation to multiple referred vars")
+    (is (reformats-to?
+         ["(ns example"
+          "(:require [thing [core :refer [timed]]]))"
+          ""
+          "(timed \"x\""
+          ":a"
+          ":b)"]
+         ["(ns example"
+          "    (:require [thing [core :refer [timed]]]))"
+          ""
+          "(timed \"x\""
+          "  :a"
+          "  :b)"]
+         {:indents {'thing.core/timed [[:inner 0]]}
+          #?@(:cljs [:refer-map {"timed" "thing.core"}])})
+        "applies custom indentation to referred vars from nested requires")
+    (is (reformats-to?
          ["(let [ns subs]"
           "  (ns \"string\"))"
           ""

--- a/docs/INDENTS.md
+++ b/docs/INDENTS.md
@@ -47,6 +47,17 @@ example:
 
 This rule would match both `com.example/foo` and `ex/foo`.
 
+Similarly, you can supply a refer map for matching unqualified symbols
+that have been referred from other namespaces:
+
+```clojure
+{:extra-indents {com.example/foo [[:inner 0]]}
+ :refer-map {foo com.example}}
+```
+
+This rule would match `com.example/foo`, `ex/foo` (if `ex` is aliased),
+and the unqualified symbol `foo` (if it's referred from `com.example`).
+
 If we want to replace the existing indentation rules, we can use the
 `:indents` option instead of `:extra-indents`. For example, to replace
 all indentation rules with a constant 2-space indentation:


### PR DESCRIPTION
This change introduces a `:refer-map` option that allows users to define mappings of referred symbol names to their fully qualified namespace names. This is particularly useful for applying indentation rules to unqualified symbols that need to match against qualified indent rules, enhancing the flexibility of the formatting tool.

Fixes #368