### PR TITLE
Add support to normalize newlines at file end

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,11 @@ In order to load the standard configuration file from Leiningen, add the
   See [INDENTS.md][] for a complete explanation. This will **replace**
   the default indents.
 
+* `:normalize-newlines-at-file-end?` -
+  true if cljfmt should ensure files end with exactly one newline
+  character. This will remove multiple trailing blank lines and ensure
+  a final newline exists. Defaults to false.
+
 * `:remove-blank-lines-in-forms?` - whether to remove blank lines inside forms
   per the [community style recommendation][no-blank-lines]. By default, this
   does not remove blank lines in pairwise constructs like `cond` or within

--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -381,6 +381,7 @@
    :indent-line-comments?                 false
    :indentation?                          true
    :indents                               default-indents
+   :normalize-newlines-at-file-end?       false
    :insert-missing-whitespace?            true
    :remove-blank-lines-in-forms?          false
    :remove-consecutive-blank-lines?       true
@@ -501,6 +502,10 @@
 
 (defn remove-trailing-whitespace [form]
   (transform form edit-all trailing-whitespace? z/remove*))
+
+(defn normalize-newlines-at-file-end [s]
+  (cond-> (str/trimr s)
+    (not (str/blank? s)) (str "\n")))
 
 (defn- replace-with-one-space [zloc]
   (z/replace* zloc (whitespace 1)))
@@ -847,7 +852,9 @@
   ([form-string options]
    (-> (p/parse-string-all form-string)
        (reformat-form options)
-       (n/string))))
+       n/string
+       (cond-> (:normalize-newlines-at-file-end? options)
+         normalize-newlines-at-file-end))))
 
 (def default-line-separator
   #?(:clj (System/lineSeparator) :cljs \newline))

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -64,6 +64,9 @@
    [nil "--[no-]remove-trailing-whitespace"
     :default (:remove-trailing-whitespace? defaults)
     :id :remove-trailing-whitespace?]
+   [nil "--[no-]normalize-newlines-at-file-end"
+    :default (:normalize-newlines-at-file-end? defaults)
+    :id :normalize-newlines-at-file-end?]
    [nil "--[no-]sort-ns-references"
     :default (:sort-ns-references? defaults)
     :id :sort-ns-references?]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -1411,6 +1411,72 @@
           :function-arguments-indentation :cursive})
         "indents properly with :function-arguments-indentation :cursive")))
 
+(deftest test-normalize-newlines-at-file-end
+  (testing "ensure exactly one newline at end of file"
+    (testing "newline when missing"
+      (is (reformats-to?
+           ["(foo bar)"]
+           ["(foo bar)"
+            ""]
+           {:normalize-newlines-at-file-end? true})))
+    (testing "does not add extra newline when already present"
+      (is (reformats-to?
+           ["(foo bar)"
+            ""]
+           ["(foo bar)"
+            ""]
+           {:normalize-newlines-at-file-end? true})))
+    (testing "removes extra newlines when more than one present"
+      (is (reformats-to?
+           ["(foo bar)"
+            ""
+            ""
+            ""]
+           ["(foo bar)"
+            ""]
+           {:normalize-newlines-at-file-end? true})))
+    (testing "removes space if present on last line"
+      (is (reformats-to?
+           ["(foo bar)"
+            " "]
+           ["(foo bar)"
+            ""]
+           {:normalize-newlines-at-file-end? true}))))
+
+  (testing "preserve when disabled"
+    (is (reformats-to?
+         ["(foo bar)"
+          ""
+          ""]
+         ["(foo bar)"
+          ""
+          ""]
+         {:normalize-newlines-at-file-end? false}))
+    (is (reformats-to?
+         ["(foo bar)"]
+         ["(foo bar)"]
+         {:normalize-newlines-at-file-end? false})))
+
+  (testing "edge cases"
+    (testing "empty file remains empty"
+      (is (reformats-to?
+           [""]
+           [""]
+           {:normalize-newlines-at-file-end? true})))
+    (testing "file with only whitespace and newlines"
+      (is (reformats-to?
+           [""
+            " "
+            ""]
+           [""]
+           {:normalize-newlines-at-file-end? true})))
+    (testing "file with trailing whitespace on content line"
+      (is (reformats-to?
+           ["(foo bar) "]
+           ["(foo bar)"
+            ""]
+           {:normalize-newlines-at-file-end? true})))))
+
 (deftest test-options
   (is (reformats-to?
        ["(foo)"


### PR DESCRIPTION
This change introduces an option to insert a final newline at the end of files when formatting. It includes logic to handle various edge cases, such as preserving existing newlines and removing extra newlines or trailing whitespace. Tests have been added to ensure correct behavior when the option is enabled or disabled. 
Fixes #358