### PR TITLE
Increase native-image PageSize to 64k

### DIFF
--- a/cljfmt/project.clj
+++ b/cljfmt/project.clj
@@ -30,6 +30,7 @@
           "--report-unsupported-elements-at-runtime"
           "-H:Log=registerResource:"
           "--no-fallback"
+          "-H:PageSize=65536"
           "-J-Xmx3g"]}
   :aliases {"test-all" ["with-profile" "+cljs" "test"]}
   :profiles


### PR DESCRIPTION
Older versions of GraalVM defaulted to compiling binaries using the compilation hosts' page-size (typically 4k).

This results in the `cljfmt` binary failing to start on kernels compiled with larger page sizes - such as the Raspberry Pi 5, and Mac running Asahi Linux.

```
Fatal error: Failed to create the main Isolate. (code 8)
```

Newer versions of GraalVM native-image default to a page size of 64k which avoids producing binaries that fail to start on Linux kernels configured for more than 4k pages.

Picking a larger build-time page size is strictly more compatible (the runtime page size just needs to be <= the build-time value), so there’s no functional downside for 4k-page systems.