### PR TITLE
Align branch bodies for multi-line case keys

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -236,13 +236,19 @@
     :cursive (cursive-two-space-list-indent? zloc)
     :zprint (zprint-two-space-list-indent? zloc)))
 
-(defn- list-indent [zloc context]
-  (if (> (index-of zloc) 1)
-    (-> zloc z/leftmost* z/right margin)
-    (cond-> (coll-indent zloc)
-      (two-space-list-indent? zloc context) inc)))
-
 (def indent-size 2)
+
+(defn- inside-case-form? [zloc]
+  (z/skip z/up
+          #(not (and (= :list (z/tag %)) (-> % z/leftmost z/sexpr (= 'case))))
+          zloc))
+
+(defn- list-indent [zloc context]
+  (cond
+    (<= (index-of zloc) 1)   (cond-> (coll-indent zloc)
+                               (two-space-list-indent? zloc context) inc)
+    (inside-case-form? zloc) (inc (margin (z/up zloc)))
+    :else                    (-> zloc z/leftmost* z/right margin)))
 
 (defn- indent-width [zloc]
   (case (z/tag zloc)

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -244,6 +244,25 @@
          ["{:foo [:bar"
           "       :baz]}"])))
 
+  (testing "case multiple values for the same condition in multiple lines"
+    (is (reformats-to?
+         ["(case x"
+          "  ([:a :b] [:c :d] [:e :f]"
+          "           [:g :h]) (do-something))"]
+         ["(case x"
+          "  ([:a :b] [:c :d] [:e :f]"
+          "   [:g :h]) (do-something))"]))
+    (testing "nested into other forms"
+      (is (reformats-to?
+           ["(defn x []"
+            "(case x"
+            "  ([:a :b] [:c :d] [:e :f]"
+            "           [:g :h]) (do-something)))"]
+           ["(defn x []"
+            "  (case x"
+            "    ([:a :b] [:c :d] [:e :f]"
+            "     [:g :h]) (do-something)))"]))))
+
   (testing "embedded structures"
     (is (reformats-to?
          ["(let [foo {:x 1"


### PR DESCRIPTION
When a branch key in a `case` form is written across multiple lines, the branch body was incorrectly indented relative to the key's closing paren. That produced misaligned branch bodies and inconsistent formatting for constructs such as:

```clojure
(case 'y
  (x y z
     z) "x, y, or z"
  "default")
```

This is now formatted as 

```clojure
(case 'y
  (x y z
   z) "x, y, or z"
  "default")
```

Adjust the indentation calculation so branch bodies align with the closing paren of the multi-line key, restoring readability and consistency.

Fixes #396