### PR TITLE
Fix the config key for `blank-lines-separate-alignment` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ In order to load the standard configuration file from Leiningen, add the
    :as everything}                          ;; 27 spaces, falls back to 1 space
   ```
 
-* `blank-lines-separate-alignment` -
+* `:blank-lines-separate-alignment?` -
   true if cljfmt should treat blank lines as separators when aligning
   columns. When enabled, alignment groups are separated by blank lines,
   allowing independent alignment within each group. Defaults to false.


### PR DESCRIPTION
All other configuration keys were present as the full keyword, except for `blank-lines-separate-alignment`. This fixes it, as I was pretty confused why the config wasn't working when I had copied it from the README as all others 😄 