### PR TITLE
Fix `single-column-line?` behavior for last elements

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -631,7 +631,8 @@
                max 0 (str/split lines #"\r?\n"))))
 
 (defn- single-column-line? [zloc]
-  (and (line-break? (skip-whitespace-and-commas (z/right* zloc) z/right*))
+  (and (let [zloc (skip-whitespace-and-commas (z/right* zloc) z/right*)]
+         (or (nil? zloc) (line-break? zloc)))
        (line-break? (skip-whitespace-and-commas (z/left* zloc) z/left*))))
 
 (defn- node-str-length [zloc]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -2713,6 +2713,19 @@
           " (fn [a b c d e]"
           "   (+ a b c d e))"
           " :key  3}"]
+         {:align-map-columns? true}))
+
+    (is (reformats-to?
+         ["{:key-one 1"
+          " :key3 3"
+          " :key2"
+          " (fn [a b c d e]"
+          "   (+ a b c d e))}"]
+         ["{:key-one 1"
+          " :key3    3"
+          " :key2"
+          " (fn [a b c d e]"
+          "   (+ a b c d e))}"]
          {:align-map-columns? true})))
   (testing "let with wrapped value - :align-single-column-lines? false (default) compact alignment"
     (is (reformats-to?


### PR DESCRIPTION
I noticed that the `:single-column-line?` rule is not currently respected when the single-column element is the last one in a map. This PR fixes that.