### PR TITLE
Fix parsing ns :require vectors with #_ comments

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -219,9 +219,12 @@
        (count)
        (dec)))
 
+(defn- meta? [zloc]
+  (#{:meta :meta*} (z/tag zloc)))
+
 (defn- skip-meta [zloc]
-  (if (#{:meta :meta*} (z/tag zloc))
-    (-> zloc z/down z/right)
+  (if (meta? zloc)
+    (-> zloc z/down z/right recur)
     zloc))
 
 (defn- cursive-two-space-list-indent? [zloc]
@@ -829,13 +832,18 @@
 
 #?(:clj
    (defn- refer-zloc->refer-mapping [refer-zloc]
-     (let [refer-vec         (some-> refer-zloc z/right z/sexpr)
-           current-ns        (some-> refer-zloc leftmost-symbol z/sexpr)
-           grandparent-node  (some-> refer-zloc z/up z/up)
-           parent-ns         (ns-require-form-parent grandparent-node)]
-       (when (and (vector? refer-vec) (symbol? current-ns))
+     (let [refers           (some-> refer-zloc
+                                    (z/find-next (comp skip-meta z/right)
+                                                 (some-fn z/vector? z/list?))
+                                    z/sexpr)
+           current-ns       (some-> refer-zloc leftmost-symbol z/sexpr)
+           grandparent-node (some-> refer-zloc
+                                    (z/find-next z/up (complement meta?))
+                                    (z/find-next z/up (complement meta?)))
+           parent-ns        (ns-require-form-parent grandparent-node)]
+       (when (and (sequential? refers) (symbol? current-ns))
          (let [ns-str (join-ns-str parent-ns current-ns)]
-           (->> refer-vec (map (fn [sym] [(str sym) ns-str])) (into {})))))))
+           (->> refers (map (fn [sym] [(str sym) ns-str])) (into {})))))))
 
 #?(:clj (defn- refer-map-for-form [form]
           (when-let [req-zloc (-> form z/of-node (z/find z/next ns-require-form?))]
@@ -845,10 +853,15 @@
 
 #?(:clj
    (defn- as-zloc->alias-mapping [as-zloc]
-     (let [alias             (some-> as-zloc z/right z/sexpr)
-           current-ns        (some-> as-zloc leftmost-symbol z/sexpr)
-           grandparent-node  (some-> as-zloc z/up z/up)
-           parent-ns         (ns-require-form-parent grandparent-node)]
+     (let [alias            (some-> as-zloc
+                                    (z/find-next (comp skip-meta z/right)
+                                                 symbol-node?)
+                                    z/sexpr)
+           current-ns       (some-> as-zloc leftmost-symbol z/sexpr)
+           grandparent-node (some-> as-zloc
+                                    (z/find-next z/up (complement meta?))
+                                    (z/find-next z/up (complement meta?)))
+           parent-ns        (ns-require-form-parent grandparent-node)]
        (when (and (symbol? alias) (symbol? current-ns))
          {(str alias) (join-ns-str parent-ns current-ns)}))))
 

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -7,6 +7,7 @@
                                  replace-newlines wrap-normalize-newlines
                                  realign-form unalign-form]]
             [cljfmt.test-util.common]
+            [clojure.string :as str]
             [rewrite-clj.node :as n]
             [rewrite-clj.parser :as p])
   #?(:cljs (:require-macros [cljfmt.test-util.cljs])))
@@ -323,24 +324,36 @@
                           "#_:clj-kondo/ignore "
                           "^tag "
                           "#_old-thing "]
-              ns-vec-str [(str ignore-str "[thing.core :as t]")
-                          (str ignore-str "[thing [core :as t]]")
-                          (str ignore-str "(thing [core :as t])")
-                          (str "[" ignore-str "thing.core :as t]")
-                          (str ignore-str " [" ignore-str "thing.core :as t]")]
-              :let [ns-str (str "(ns example (:require " ns-vec-str "))")]]
-        (testing ns-str
+              require-str ["<>[<>thing.core :as <>t :refer <>[<>my-defn]]"
+                           "<>[<>thing <>[<>core :as <>t :refer <>[<>my-defn]]]"]
+              :let [ns-str (str "(ns my-namespace (:require " require-str "))")]
+              ns-str [ns-str
+                      (-> ns-str
+                          (str/replace #"\[" "(")
+                          (str/replace #"\]" ")"))]
+              ns-str [(str/replace ns-str #"<>" ignore-str)
+                      (str/replace ns-str #"<>" (str ignore-str ignore-str))]]
+        (testing (str \newline (pr-str ns-str))
           (is (reformats-to?
                [ns-str
                 ""
                 "(t/defn foo [x]"
+                "(+ x 1))"
+                ""
+                "(my-defn foo [x]"
                 "(+ x 1))"]
                [ns-str
                 ""
                 "(t/defn foo [x]"
+                "  (+ x 1))"
+                ""
+                "(my-defn foo [x]"
                 "  (+ x 1))"]
-               {:indents {'ns [[:block 1]], 'thing.core/defn [[:inner 0]]}
-                #?@(:cljs [:alias-map {"t" "thing.core"}])})))))
+               {:indents {'ns                 [[:block 1]]
+                          'thing.core/defn    [[:inner 0]]
+                          'thing.core/my-defn [[:inner 0]]}
+                #?@(:cljs [:alias-map {"t" "thing.core"}
+                           :refer-map {"my-defn" "thing.core"}])})))))
     (is (reformats-to?
          ["(comment)"
           "(ns thing.core)"


### PR DESCRIPTION
Fixes #415 

Metadata `^...` or uneval `#_` comment forms in various places in a form within `ns` `:require` weren't handled correctly (before the RHS symbol of `:as`, before the `:refers` vector, before symbols within `:refers`, etc.), so I fixed everything and made the tests must more comprehensive; I also realized that technically `:refer (x)` (list instead of vector) is legal so I updated this to handle that situation as well.