### PR TITLE
Don't remove blank lines from exempted forms in function literals

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -743,14 +743,17 @@
 
 (defn- matching-form-index? [zloc [k indexes] context]
   (if (= :all indexes)
-    (and (z/list? zloc)
+    (and (or (z/list? zloc)
+             (= (z/tag zloc) :fn))
          (form-matches-key? (z/down zloc) k context))
     (and (z/list? (z/up zloc))
          (form-matches-key? zloc k context)
          (contains? (set indexes) (dec (index-of zloc))))))
 
 (defn- matching-form? [zloc form-indexes context]
-  (and (or (z/list? zloc) (z/list? (z/up zloc)))
+  (and (or (z/list? zloc)
+           (= (z/tag zloc) :fn)
+           (z/list? (z/up zloc)))
        (some #(matching-form-index? zloc % context) form-indexes)))
 
 (defn align-form-columns [form aligned-forms opts]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -1422,6 +1422,22 @@
                   "  (sequential? x)"
                   "  :seq)"]]
         (is (reformats-to? form form {:remove-blank-lines-in-forms? true}))))
+    (testing "Handle #() function literals"
+      (let [form ["(defn increase [y]"
+                  "  (let [f #(cond"
+                  "             (pos? y)"
+                  "             (inc %)"
+                  ""
+                  "             (neg? y)"
+                  "             (dec %)"
+                  ""
+                  "             :else"
+                  "             %)]"
+                  "    (f y)))"]]
+        (is (reformats-to?
+             form
+             form
+             {:remove-blank-lines-in-forms? true}))))
     (testing (str ":blank-line-forms :all should only exempt the immediate"
                   " children of the form")
       (is (reformats-to?


### PR DESCRIPTION
Fixes #419