### PR TITLE
Add support for line-breaks-in-ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,19 @@ In order to load the standard configuration file from Leiningen, add the
   See [INDENTS.md][] for a complete explanation. This will **replace**
   the default indents.
 
+* `:line-breaks-in-ns` -
+  - `:none` if cljfmt should leave line breaks within `ns` alone.
+  - `:multiple` to only break lines when there are multiple dependencies,
+    while keeping single dependencies next to the `ns` reference symbol.
+    This follows [Clojure Style Guide: Line breaks in
+ns](https://github.com/bbatsov/clojure-style-guide#line-breaks-in-ns)
+  - `:always` to move all dependencies to separate lines from the `ns`
+    reference symbol. This follows [Stuart
+Sierra: How to ns - Line
+Breaks](https://stuartsierra.com/2016/clojure-how-to-ns.html#line-breaks).
+
+  Defaults to `:none`
+
 * `:normalize-newlines-at-file-end?` -
   true if cljfmt should ensure files end with exactly one newline
   character. This will remove multiple trailing blank lines and ensure

--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -212,6 +212,11 @@
 (defn- uneval? [zloc]
   (= (z/tag zloc) :uneval))
 
+(defn- right-siblings [zloc]
+  (->> (iterate z/right zloc)
+       (remove uneval?)
+       (take-while identity)))
+
 (defn- index-of [zloc]
   (->> (iterate z/left zloc)
        (remove uneval?)
@@ -392,6 +397,7 @@
    :indent-line-comments?                 false
    :indentation?                          true
    :indents                               default-indents
+   :line-breaks-in-ns                    :none
    :normalize-newlines-at-file-end?       false
    :insert-missing-whitespace?            true
    :remove-blank-lines-in-forms?          false
@@ -607,6 +613,39 @@
 
 (defn sort-ns-references [form]
   (transform form edit-all ns-reference? sort-arguments))
+
+(defn- split-dependencies [zloc]
+  (loop [z zloc]
+    (let [z' (if (preceded-by-line-break? z) z (z/insert-left* z (n/newlines 1)))]
+      (if-let [nxt (z/right z')]
+        (recur nxt)
+        (z/up z')))))
+
+(defn- collapse-dependency [zloc req-node]
+  (let [nodes-between (->> (iterate z/left* (z/left* zloc))
+                           (take-while #(and % (not= (z/node %) req-node))))]
+    (if (some comment? nodes-between)
+      (z/up zloc)
+      (loop [z (z/left* zloc)]
+        (if (= (z/node z) req-node)
+          (z/up z)
+          (recur (if (clojure-whitespace? z)
+                   (z/remove* z)
+                   (z/left* z))))))))
+
+(defn- align-ns-references [zloc mode]
+  (let [req (z/down zloc)
+        dep (z/right req)
+        deps (count (right-siblings dep))]
+    (cond
+      (> deps 1) (split-dependencies dep)
+      (not= deps 1) zloc
+      (= mode :always) (split-dependencies dep)
+      (preceded-by-line-break? dep) (collapse-dependency dep (z/node req))
+      :else zloc)))
+
+(defn line-breaks-in-ns [form opts]
+  (transform form edit-all ns-reference? #(align-ns-references % (:line-breaks-in-ns opts))))
 
 (defn- reduce-columns [zloc f init]
   (loop [zloc zloc, col 0, acc init]
@@ -906,6 +945,8 @@
      (-> form
          (cond-> (:sort-ns-references? opts)
            sort-ns-references)
+         (cond-> (not= (:line-breaks-in-ns opts) :none)
+           (line-breaks-in-ns opts))
          (cond-> (:split-keypairs-over-multiple-lines? opts)
            split-keypairs-over-multiple-lines)
          (cond-> (:remove-consecutive-blank-lines? opts)

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -54,6 +54,12 @@
    [nil "--[no-]insert-missing-whitespace"
     :default (:insert-missing-whitespace? defaults)
     :id :insert-missing-whitespace?]
+   [nil "--line-breaks-in-ns MODE"
+    "MODE may be none, always, or multiple"
+    :default (:line-breaks-in-ns defaults)
+    :parse-fn keyword
+    :validate [#{:none :always :multiple}
+               "Must be none, always, or multiple"]]
    [nil "--[no-]parallel"
     :id :parallel?
     :default (:parallel? defaults)]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -2125,6 +2125,159 @@
         "   [com.example.ERP.service :as erp]))"]
        {:sort-ns-references? true})))
 
+(deftest test-line-breaks-in-ns
+  (testing "line breaks with multiple dependencies"
+    (is (reformats-to?
+         ["(ns foo"
+          "  (:require"
+          "   b"
+          "   c"
+          "   a))"]
+         ["(ns foo"
+          "  (:require"
+          "   b"
+          "   c"
+          "   a))"]
+         {:line-breaks-in-ns :multiple}))
+    (is (reformats-to?
+         ["(ns foo"
+          "  (:require b c a))"]
+         ["(ns foo"
+          "  (:require"
+          "   b"
+          "   c"
+          "   a))"]
+         {:line-breaks-in-ns :multiple}))
+    (is (reformats-to?
+         ["(ns foo"
+          "  (:require b"
+          "            c"
+          "            a))"]
+         ["(ns foo"
+          "  (:require"
+          "   b"
+          "   c"
+          "   a))"]
+         {:line-breaks-in-ns :multiple}))
+    (is (reformats-to?
+         ["(ns foo"
+          "  (:require b"
+          "            [c :as d]"
+          "            a))"]
+         ["(ns foo"
+          "  (:require"
+          "   b"
+          "   [c :as d]"
+          "   a))"]
+         {:line-breaks-in-ns :multiple}))
+    (is (reformats-to?
+         ["(ns foo.bar"
+          "  (:require [c]"
+          "            [a.b :as b] ;; aabb"
+          "            ;; bbb"
+          "            b))"]
+         ["(ns foo.bar"
+          "  (:require"
+          "   [c]"
+          "   [a.b :as b] ;; aabb"
+          "   ;; bbb"
+          "   b))"]
+         {:line-breaks-in-ns    :multiple
+          :indent-line-comments? true}))
+    (is (reformats-to?
+         ["(ns foo.bar"
+          "  (:require [c]"
+          "            ^:keep a"
+          "            #?(:clj d)"
+          "            ^{:x 1} b))"]
+         ["(ns foo.bar"
+          "  (:require"
+          "   [c]"
+          "   ^:keep a"
+          "   #?(:clj d)"
+          "   ^{:x 1} b))"]
+         {:line-breaks-in-ns :multiple}))
+    (is (reformats-to?
+         ["(ns foo.bar"
+          "  (:require [c]"
+          "            ^:keep a"
+          "            #?(:clj d)"
+          "            ^{:x 1} b))"]
+         ["(ns foo.bar"
+          "  (:require"
+          "    [c]"
+          "    ^:keep a"
+          "    #?(:clj d)"
+          "    ^{:x 1} b))"]
+         {:line-breaks-in-ns              :multiple
+          :function-arguments-indentation :cursive}))
+    (is (reformats-to?
+         ["(ns foo"
+          "  (:import a.b c.d [e.f G] [h.i J K]))"]
+         ["(ns foo"
+          "  (:import"
+          "   a.b"
+          "   c.d"
+          "   [e.f G]"
+          "   [h.i J K]))"]
+         {:line-breaks-in-ns :multiple}))
+    (is (reformats-to?
+         ["(ns foo"
+          "  (:import a.b"
+          "           c.d"
+          "           (e.f G"
+          "                H"
+          "                I)))"]
+         ["(ns foo"
+          "  (:import"
+          "   a.b"
+          "   c.d"
+          "   (e.f G"
+          "        H"
+          "        I)))"]
+         {:line-breaks-in-ns :multiple}))
+    (is (reformats-to?
+         ["(ns foo"
+          "  (:require a b [e.f :as f :refer [g]] [i.j :as j :refer [k l]]))"]
+         ["(ns foo"
+          "  (:require"
+          "   a"
+          "   b"
+          "   [e.f :as f :refer [g]]"
+          "   [i.j :as j :refer [k l]]))"]
+         {:line-breaks-in-ns :multiple})))
+  (testing "no line break for single dependency"
+    (is (reformats-to?
+         ["(ns foo"
+          "  (:require a)"
+          "  (:import b))"]
+         ["(ns foo"
+          "  (:require a)"
+          "  (:import b))"]
+         {:line-breaks-in-ns :multiple}))
+    (is (reformats-to?
+         ["(ns foo"
+          "  (:require"
+          "   a))"]
+         ["(ns foo"
+          "  (:require a))"]
+         {:line-breaks-in-ns :multiple}))
+    (is (reformats-to?
+         ["(ns foo"
+          "  (:require a))"]
+         ["(ns foo"
+          "  (:require"
+          "   a))"]
+         {:line-breaks-in-ns :always}))
+    (is (reformats-to?
+         ["(ns foo"
+          "  (:require"
+          "   a))"]
+         ["(ns foo"
+          "  (:require"
+          "   a))"]
+         {:line-breaks-in-ns :always}))))
+
 (deftest cursive-and-zprint-function-argument-indents-depend-on-first-element
   (let [input ["(foo"
                "bar)"


### PR DESCRIPTION
Adds new configuration option `:line-breaks-in-ns` that allows for consistent line breaks within `ns` `:require`, `:import`, etc.

The reason for the change is:

- Consistent formatting of `ns`
- Easier manual sorting (e.g. Emacs `sort-lines`)
- Improved readability of `ns` declarations
- Cleaner diffs for dependency changes

The implementation requires an input of:

- `:none` (default) - no enforceable line breaks in `ns`.

- `:multiple` - ensures singular dependencies are moved to the same line as the `ns` reference symbol. Multiple dependencies are broken out into separate lines below the `ns` reference symbol. `:multiple` is consistent with [Clojure Style Guide: Line breaks in ns](https://github.com/bbatsov/clojure-style-guide#line-breaks-in-ns)

- `:always` - ensures all dependencies are moved to separate lines from the `ns` reference symbol. `:always` is consistent with [Stuart Sierra: How to ns - Line Breaks](https://stuartsierra.com/2016/clojure-how-to-ns.html#line-breaks)

This commit resolves one of two features requested by #335.