### PR TITLE
fix single-column-line? to detect first element in collection

### DIFF
--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -634,9 +634,10 @@
                max 0 (str/split lines #"\r?\n"))))
 
 (defn- single-column-line? [zloc]
-  (and (let [zloc (skip-whitespace-and-commas (z/right* zloc) z/right*)]
-         (or (nil? zloc) (line-break? zloc)))
-       (line-break? (skip-whitespace-and-commas (z/left* zloc) z/left*))))
+  (and (let [right (skip-whitespace-and-commas (z/right* zloc) z/right*)]
+         (or (nil? right) (line-break? right)))
+       (let [left (skip-whitespace-and-commas (z/left* zloc) z/left*)]
+         (or (nil? left) (line-break? left)))))
 
 (defn- node-str-length [zloc]
   (-> zloc z/node n/string count))

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -2798,6 +2798,32 @@
           " :key             3}"]
          {:align-map-columns?         true
           :align-single-column-lines? true})))
+  (testing "map with first-position wrapped value, true"
+    (is (reformats-to?
+         ["{:very-long-map-key"
+          " wrapped-value"
+          " :host \"localhost\""
+          " :port 5432"
+          " :timeout 30}"]
+         ["{:very-long-map-key"
+          " wrapped-value"
+          " :host              \"localhost\""
+          " :port              5432"
+          " :timeout           30}"]
+         {:align-map-columns?         true
+          :align-single-column-lines? true})))
+  (testing "map with last-position wrapped value, true"
+    (is (reformats-to?
+         ["{:short 1"
+          " :timeout 30"
+          " :very-long-key"
+          " wrapped}"]
+         ["{:short         1"
+          " :timeout       30"
+          " :very-long-key"
+          " wrapped}"]
+         {:align-map-columns?         true
+          :align-single-column-lines? true})))
   (testing "let with wrapped value - :align-single-column-lines? true causes excessive padding"
     (is (reformats-to?
          ["(let [a 2"
@@ -2812,6 +2838,34 @@
           "        (+ e 1 1 1 1 1 1 1 1))"
           "      c                        3]"
           "  (+ a c))"]
+         {:align-form-columns?        true
+          :align-single-column-lines? true})))
+  (testing "let with first-position wrapped value, true"
+    (is (reformats-to?
+         ["(let [{:keys [endpoint mapper]}"
+          "      (get-in config [:auth])"
+          "      token (get response \"access_token\")"
+          "      type (get response \"token_type\")]"
+          "  {:token token})"]
+         ["(let [{:keys [endpoint mapper]}"
+          "      (get-in config [:auth])"
+          "      token                     (get response \"access_token\")"
+          "      type                      (get response \"token_type\")]"
+          "  {:token token})"]
+         {:align-form-columns?        true
+          :align-single-column-lines? true})))
+  (testing "let with last-position wrapped value, true"
+    (is (reformats-to?
+         ["(let [short 1"
+          "      longer-key 2"
+          "      {:keys [endpoint mapper]}"
+          "      (get-in config [:auth])]"
+          "  [short longer-key])"]
+         ["(let [short                     1"
+          "      longer-key                2"
+          "      {:keys [endpoint mapper]}"
+          "      (get-in config [:auth])]"
+          "  [short longer-key])"]
          {:align-form-columns?        true
           :align-single-column-lines? true})))
   (testing "map with wrapped value - :align-single-column-lines? false (default) compact alignment"
@@ -2840,6 +2894,32 @@
           " (fn [a b c d e]"
           "   (+ a b c d e))}"]
          {:align-map-columns? true})))
+  (testing "map with first-position wrapped value, false"
+    (is (reformats-to?
+         ["{:very-long-map-key"
+          " wrapped-value"
+          " :host \"localhost\""
+          " :port 5432"
+          " :timeout 30}"]
+         ["{:very-long-map-key"
+          " wrapped-value"
+          " :host    \"localhost\""
+          " :port    5432"
+          " :timeout 30}"]
+         {:align-map-columns?         true
+          :align-single-column-lines? false})))
+  (testing "map with last-position wrapped value, false"
+    (is (reformats-to?
+         ["{:short 1"
+          " :timeout 30"
+          " :very-long-key"
+          " wrapped}"]
+         ["{:short   1"
+          " :timeout 30"
+          " :very-long-key"
+          " wrapped}"]
+         {:align-map-columns?         true
+          :align-single-column-lines? false})))
   (testing "let with wrapped value - :align-single-column-lines? false (default) compact alignment"
     (is (reformats-to?
          ["(let [a 2"
@@ -2855,6 +2935,34 @@
           "      c 3]"
           "  (+ a c))"]
          {:align-form-columns? true})))
+  (testing "let with first-position wrapped value, false"
+    (is (reformats-to?
+         ["(let [{:keys [endpoint mapper]}"
+          "      (get-in config [:auth])"
+          "      token (get response \"access_token\")"
+          "      type (get response \"token_type\")]"
+          "  {:token token})"]
+         ["(let [{:keys [endpoint mapper]}"
+          "      (get-in config [:auth])"
+          "      token (get response \"access_token\")"
+          "      type  (get response \"token_type\")]"
+          "  {:token token})"]
+         {:align-form-columns?        true
+          :align-single-column-lines? false})))
+  (testing "let with last-position wrapped value, false"
+    (is (reformats-to?
+         ["(let [short 1"
+          "      longer-key 2"
+          "      {:keys [endpoint mapper]}"
+          "      (get-in config [:auth])]"
+          "  [short longer-key])"]
+         ["(let [short      1"
+          "      longer-key 2"
+          "      {:keys [endpoint mapper]}"
+          "      (get-in config [:auth])]"
+          "  [short longer-key])"]
+         {:align-form-columns?        true
+          :align-single-column-lines? false})))
   (testing "normal alignment unaffected when all values are on same line"
     (is (reformats-to?
          ["{:short 1"


### PR DESCRIPTION
@weavejester I can't remember if you want an issue per PR, so I included the details here.  I can make it an issue if you prefer.

### LLM notice
I have reviewed all of what is being submitted.  The PR description was partially generated with llm to show the current and expected.  The test cases were partially generated with llm to cover all the permutations. 

## Problem

`:align-single-column-lines? false` does not suppress anchor inflation when the wrapped form is the **first** binding in a `let` or the first entry in a map. The first-position element is always treated as an alignment anchor, producing the same excessive padding as `:align-single-column-lines? true`.

The underlying cause is in `single-column-line?`, which identifies whether a node is the sole element on its line. It checks for a linebreak to the left of the node, but the first element in a collection has no left sibling — `z/left*` returns nil, `line-break?` of nil returns false, and the element is never recognized as single-column regardless of what is on its right.

## Current behavior

### Form columns

Config: `{:align-form-columns? true, :align-single-column-lines? false}`

Input:
```clojure
(let [{:keys [endpoint mapper]}
      (get-in config [:auth])
      token (get response "access_token")
      type (get response "token_type")]
  {:token token})
```

Output — first-position wrapped binding used as anchor despite `false`:
```clojure
(let [{:keys [endpoint mapper]}
      (get-in config [:auth])
      token                     (get response "access_token")
      type                      (get response "token_type")]
  {:token token})
```

### Map columns

Config: `{:align-map-columns? true, :align-single-column-lines? false}`

Input:
```clojure
{:very-long-map-key
 wrapped-value
 :host "localhost"
 :port 5432
 :timeout 30}
```

Output — first-position entry used as anchor despite `false`:
```clojure
{:very-long-map-key
 wrapped-value
 :host              "localhost"
 :port              5432
 :timeout           30}
```

## Expected behavior

### Form columns

```clojure
;; first-position wrapped binding excluded; token and type align locally
(let [{:keys [endpoint mapper]}
      (get-in config [:auth])
      token (get response "access_token")
      type  (get response "token_type")]
  {:token token})
```

### Map columns

```clojure
;; first-position entry excluded; :host/:port align to :timeout
{:very-long-map-key
 wrapped-value
 :host    "localhost"
 :port    5432
 :timeout 30}
```

## Fix

`single-column-line?` currently requires a linebreak to the left:

```clojure
(line-break? (skip-whitespace-and-commas (z/left* zloc) z/left*))
```

A nil result (first element in collection) is treated as false. The fix treats nil
the same as a linebreak:

```clojure
(let [left (skip-whitespace-and-commas (z/left* zloc) z/left*)]
  (or (nil? left) (line-break? left)))
```

Tests cover all three positions (first, middle, last) for both `align-form-columns?`
and `align-map-columns?`, with both `true` and `false` flag values, added to the
existing `test-align-single-column-lines-option` deftest.
