### PR TITLE
add max-column-anchor-gap to align columns to the gap instead of collapsing on row with short keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,29 @@ In order to load the standard configuration file from Leiningen, add the
    :as everything}                          ;; 27 spaces, falls back to 1 space
   ```
 
+* `:max-column-alignment-width` -
+  a positive integer that limits which keys participate in column
+  alignment. Keys whose end column is at or within N are aligned
+  together; keys that end past column N are not padded and receive a
+  single space before their value. Defaults to nil (no limit).
+  **Experimental.**
+
+  ```clojure
+  ;; Input:
+  {:a 1
+   :abcde 2
+   :abcdefg 3
+   :long-name 4}
+
+  ;; With :align-map-columns? true and :max-column-alignment-width 7:
+  ;; :a and :abcde end at or within column 7 and align together;
+  ;; :abcdefg and :long-name end past column 7 and are not padded
+  {:a     1      ;; ends within column 7, padded to value column
+   :abcde 2      ;; ends at column 7, sets the value column
+   :abcdefg 3    ;; ends past column 7, 1 space
+   :long-name 4} ;; ends past column 7, 1 space
+  ```
+
 * `:blank-lines-separate-alignment?` -
   true if cljfmt should treat blank lines as separators when aligning
   columns. When enabled, alignment groups are separated by blank lines,

--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -383,6 +383,7 @@
    :align-single-column-lines?            false
    :aligned-forms                         default-aligned-forms
    :max-column-alignment-gap              nil
+   :max-column-alignment-width            nil
    :blank-line-forms                      blank-line-forms
    :blank-lines-separate-alignment?       false
    :extra-aligned-forms                   {}
@@ -670,13 +671,17 @@
 (defn- count-spaces [zloc]
   (if (space? zloc) (node-str-length zloc) 0))
 
-(defn- pad-to-position [zloc start-position {max-gap :max-column-alignment-gap}]
-  {:pre [(or (nil? max-gap) (pos-int? max-gap))]}
-  (let [delta (- start-position (margin zloc))]
-    (if max-gap
-      (let [old-gap (count-spaces (z/left* zloc))
-            new-gap (+ old-gap delta)]
-        (pad-node zloc (if (> new-gap max-gap) (- 1 old-gap) delta)))
+(defn- pad-to-position
+  [zloc start-position {max-gap     :max-column-alignment-gap
+                        align-width :max-column-alignment-width}]
+  {:pre [(or (nil? max-gap) (pos-int? max-gap))
+         (or (nil? align-width) (pos-int? align-width))]}
+  (let [old-gap (count-spaces (z/left* zloc))
+        delta   (- start-position (margin zloc))
+        new-gap (+ old-gap delta)]
+    (if (or (< new-gap 1)
+            (and max-gap (> new-gap max-gap)))
+      (pad-node zloc (- 1 old-gap))
       (pad-node zloc delta))))
 
 (defn- edit-column [zloc column f]
@@ -707,17 +712,24 @@
           (recur (z/right* zloc) 0 acc)
           (recur (z/right* zloc) (inc col) (f zloc col acc)))))))
 
-(defn- column-start-position [zloc col opts]
-  (let [reduce-fn (if (:blank-lines-separate-alignment? opts)
+(defn- column-start-position
+  [zloc col {align-width    :max-column-alignment-width
+             align-singles? :align-single-column-lines?
+             separate?      :blank-lines-separate-alignment?}]
+  (let [reduce-fn (if separate?
                     reduce-column-group
                     reduce-columns)
-        maximizer (fn [zloc c max-pos]
+        collector (fn [zloc c positions]
                     (if (and (= c (dec col))
-                             (or (:align-single-column-lines? opts)
+                             (or align-singles?
                                  (not (single-column-line? zloc))))
-                      (max max-pos (node-end-position zloc))
-                      max-pos))]
-    (inc (reduce-fn zloc maximizer 0))))
+                      (conj positions (node-end-position zloc))
+                      positions))
+        positions (reduce-fn zloc collector [])
+        threshold (when align-width (+ (apply min 0 positions) align-width))]
+    (inc (apply max 0 (if threshold
+                        (filter #(<= % threshold) positions)
+                        positions)))))
 
 (defn- align-one-column
   [zloc col {:keys [blank-lines-separate-alignment?] :as opts}]

--- a/cljfmt/src/cljfmt/main.clj
+++ b/cljfmt/src/cljfmt/main.clj
@@ -30,6 +30,10 @@
     :default (:max-column-alignment-gap defaults)
     :parse-fn #(cond-> % (string? %) parse-long)
     :id :max-column-alignment-gap]
+   [nil "--max-column-alignment-width"
+    :default (:max-column-alignment-width defaults)
+    :parse-fn #(cond-> % (string? %) parse-long)
+    :id :max-column-alignment-width]
    [nil "--[no-]ansi"
     :default (:ansi? defaults)
     :id :ansi?]

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -3193,6 +3193,47 @@
          {:align-map-columns?       true
           :max-column-alignment-gap 5}))))
 
+(deftest test-max-column-alignment-width
+  (testing "form: anchor demoted until all keys fit within width"
+    (is (reformats-to?
+         ["(let [a 1"
+          "      abcde 2"
+          "      abcdefg 3"
+          "      long-name 4]"
+          "  [a abcde abcdefg long-name])"]
+         ["(let [a     1"
+          "      abcde 2"
+          "      abcdefg 3"
+          "      long-name 4]"
+          "  [a abcde abcdefg long-name])"]
+         {:align-form-columns?        true
+          :max-column-alignment-width 11})))
+  (testing "map: anchor demoted until all keys fit within width"
+    (is (reformats-to?
+         ["{:a \"x\""
+          " :abcde \"y\""
+          " :abcdefg \"z\""
+          " :long-key \"w\"}"]
+         ["{:a     \"x\""
+          " :abcde \"y\""
+          " :abcdefg \"z\""
+          " :long-key \"w\"}"]
+         {:align-map-columns?         true
+          :max-column-alignment-width 7})))
+  (testing "composing both flags refines alignment further"
+    (is (reformats-to?
+         ["{:x \"a\""
+          " :abc \"b\""
+          " :abcde \"c\""
+          " :long-key \"d\"}"]
+         ["{:x \"a\""
+          " :abc   \"b\""
+          " :abcde \"c\""
+          " :long-key \"d\"}"]
+         {:align-map-columns?         true
+          :max-column-alignment-width 7
+          :max-column-alignment-gap   3}))))
+
 (deftest test-realign-form
   (is (= "
 {:x   1


### PR DESCRIPTION
@weavejester I can't remember if you want an issue per PR, so I included the details here.  I can make it an issue if you prefer.

### LLM notice
I have reviewed all of what is being submitted.  The PR description was partially generated with llm to show the current and expected.

## Problem

Here, I am not sure if this is a bug or a differene in expected behavior so I went with a new flag.

When `:max-column-alignment-gap` is set, the alignment anchor is still the longest key in the form. Individual rows whose gap would exceed the limit fall back to a single space, but rows with medium-length keys are still extended all the way to the inflated anchor column. This produces inconsistent alignment: the shortest key falls back, medium keys over-extend, and the longest key (which caused the problem) sets the column for all of them.

## Current behavior

Config: `{:align-form-columns? true, :max-column-alignment-gap 5}`

Input:
```clojure
(let [a 1
      abcde 2
      abcdefg 3
      long-name 4]
  [a abcde abcdefg long-name])
```

Output — `long-name` stays as anchor; `a` falls back (gap 9 > 5); `abcde` and
`abcdefg` extend unnecessarily to the `long-name` column:
```clojure
(let [a 1
      abcde     2
      abcdefg   3
      long-name 4]
  [a abcde abcdefg long-name])
```

The same behavior affects maps with `:align-map-columns?`.

## Solution

This PR does not change the behavior of `:max-column-alignment-gap`. Instead it introduces a new flag, `:max-column-anchor-gap`, which applies the limit at anchor selection time rather than per row.

When `:max-column-anchor-gap N` is set, cljfmt selects the largest key for which every shorter key would need at most N spaces to align. Keys longer than the chosen anchor are not padded.

## Expected behavior

Config: `{:align-form-columns? true, :max-column-anchor-gap 5}`

```clojure
;; long-name (gap 8 from a) and abcdefg (gap 6 from a) exceed limit;
;; anchor demotes to abcde (gap for a = 4 ≤ 5)
(let [a     1
      abcde 2
      abcdefg 3
      long-name 4]
  [a abcde abcdefg long-name])
```

## Composing both flags

The two flags are orthogonal and can be combined. `:max-column-anchor-gap` runs
first to select a conservative anchor; `:max-column-alignment-gap` then applies
per-row fallback to the result.

```clojure
;; Config: {:align-map-columns? true
;;          :max-column-anchor-gap 5       ; long-key excluded; anchor = :abcde
;;          :max-column-alignment-gap 3}   ; further trims rows with gap > 3
;;
;; :x falls back (gap 4 > 3); :abc aligns (gap 3 = limit); :abcde is anchor
{:x "a"
 :abc   "b"
 :abcde "c"
 :long-key "d"}
```

## Changes

- New option `:max-column-anchor-gap` added to `default-options` (nil by default)
- `column-start-position` applies cascade demotion when `:max-column-anchor-gap` is set
- `pad-to-position` gains a guard for keys wider than the demoted anchor, preventing
  their spacing from collapsing to zero
- README documents the new option and its relationship to `:max-column-alignment-gap`
- New `test-max-column-anchor-gap` deftest with form, map, and compose cases

## Comparison

https://github.com/user-attachments/assets/bd613ef0-1a6f-4b95-8321-541cabb82193


