### PR TITLE
Demo: Add :break-on formatting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,69 @@ In order to load the standard configuration file from Leiningen, add the
   allowing independent alignment within each group. Defaults to false.
   **Experimental.**
 
+* `:break-on` -
+  a map that enables breaking of long lines at word boundaries. Each
+  entry takes a line length limit (number of characters); lines that
+  exceed the limit are wrapped. Defaults to nil (disabled).
+
+  * `:doc-strings` - a line length limit for docstrings in
+    `defn`/`defn-`/`defmacro` forms. Docstrings longer than the limit
+    are wrapped at word boundaries, with continuation lines indented to
+    match the docstring:
+
+    ```clojure
+    ;; With :break-on {:doc-strings 40}:
+    (defn foo
+      "AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF
+      GGGGG"
+      [x]
+      x)
+    ```
+
+  * `:comments` - a line length limit for `;;` comments. Comments
+    longer than the limit are wrapped at word boundaries, with
+    continuation lines starting with `;;`:
+
+    ```clojure
+    ;; With :break-on {:comments 40}:
+    ;; AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF
+    ;; GGGGG HHHHH
+    ```
+
+  * `:defn-params` - a map of limits for `defn`/`defn-`/`defmacro`
+    forms. May contain `:break-vector`, which moves the parameter
+    vector (and body) onto their own lines when a `defn` line exceeds
+    the limit, and `:break-each`, which breaks each parameter onto its
+    own line:
+
+    ```clojure
+    ;; With :break-on {:defn-params {:break-vector 40 :break-each 20}}:
+    (defn f
+      [alpha
+       beta
+       gamma
+       delta
+       epsilon]
+      body)
+    ```
+
+  * `:binding-forms` - a map of limits for binding forms such as
+    `fn`, `let`, `loop`, `for` and `if-let`. May contain
+    `:break-vector`, which moves the body onto its own line when the
+    form line exceeds the limit, and `:break-each`, which breaks each
+    parameter (for `fn`-like forms) or each binding pair (for
+    `let`-like forms) onto its own line:
+
+    ```clojure
+    ;; With :break-on {:binding-forms {:break-vector 30 :break-each 15}}:
+    (fn [alpha
+         beta
+         gamma
+         delta
+         epsilon]
+      body)
+    ```
+
 * `:blank-line-forms` -
   a map of symbols that tell cljfmt which forms are allowed to have
   blank lines inside of them. The value may be either `:all`, which

--- a/cljfmt/src/cljfmt/config.clj
+++ b/cljfmt/src/cljfmt/config.clj
@@ -47,9 +47,19 @@
 (s/def ::aligned-forms          (s/map-of ::one-indent-key any?))
 (s/def ::extra-aligned-forms    (s/map-of ::one-indent-key any?))
 
+(s/def ::break-vector pos-int?)
+(s/def ::break-each   pos-int?)
+(s/def ::doc-strings  pos-int?)
+(s/def ::comments     pos-int?)
+(s/def ::defn-params  (s/keys :opt-un [::break-vector ::break-each]))
+(s/def ::binding-forms (s/keys :opt-un [::break-vector ::break-each]))
+(s/def ::break-on     (s/keys :opt-un [::doc-strings ::comments
+                                       ::defn-params ::binding-forms]))
+
 (s/def ::config (s/keys :opt-un [::indents ::extra-indents
                                  ::blank-line-forms ::extra-blank-line-forms
-                                 ::aligned-forms ::extra-aligned-forms]))
+                                 ::aligned-forms ::extra-aligned-forms
+                                 ::break-on]))
 
 (s/check-asserts true)
 

--- a/cljfmt/src/cljfmt/core.cljc
+++ b/cljfmt/src/cljfmt/core.cljc
@@ -385,6 +385,7 @@
    :max-column-alignment-gap              nil
    :blank-line-forms                      blank-line-forms
    :blank-lines-separate-alignment?       false
+   :break-on                              {}
    :extra-aligned-forms                   {}
    :extra-blank-line-forms                {}
    :extra-indents                         {}
@@ -522,6 +523,233 @@
 
 (defn remove-multiple-non-indenting-spaces [form]
   (transform form edit-all non-indenting-whitespace? replace-with-one-space))
+
+(defn- string-token? [zloc]
+  (and zloc (= (z/tag zloc) :token) (string? (z/sexpr zloc))))
+
+(defn- current-line-width [zloc]
+  (transduce (map count) max 0
+             (str/split (str (prior-line-string zloc) (z/string zloc))
+                        #"\r?\n")))
+
+(def ^:private def-docstring-symbols #{'defn 'defn- 'defmacro})
+
+(defn- docstring? [zloc]
+  (and (string-token? zloc)
+       (when-let [parent (z/up* zloc)]
+         (and (z/list? parent)
+              (contains? def-docstring-symbols (z/sexpr (z/down parent)))
+              (#{2 3} (index-of zloc))))))
+
+(defn- pack-words
+  "Greedily pack a sequence of words into lines of at most `budget` characters."
+  [words budget]
+  (loop [words words, lines [], cur []]
+    (if (seq words)
+      (let [word  (first words)
+            width (count (str/join " " (conj cur word)))]
+        (if (and (seq cur) (> width budget))
+          (recur (rest words) (conj lines cur) [word])
+          (recur (rest words) lines (conj cur word))))
+      (conj lines cur))))
+
+(defn- wrap-docstring [zloc limit]
+  (let [src    (z/string zloc)
+        margin (margin zloc)
+        inner  (subs src 1 (dec (count src)))
+        budget (- limit margin 1)
+        lines  (pack-words (str/split inner #"\s+") budget)]
+    (if (> (count lines) 1)
+      (z/replace* zloc
+        (n/string-node
+          (map-indexed (fn [i words]
+                         (str (when (pos? i)
+                                (str/join (repeat margin " ")))
+                              (str/join " " words)))
+                       lines)))
+      zloc)))
+
+(defn- break-doc-strings [form limit]
+  (transform form edit-all
+             #(and (docstring? %) (>= (current-line-width %) limit))
+             #(wrap-docstring % limit)))
+
+(defn- wrap-comment [zloc limit]
+  (let [s      (z/string zloc)
+        nl?    (re-find #"\r?\n$" s)
+        m      (margin zloc)
+        body   (-> s (str/replace #"^;;+" "") (str/replace #"\r?\n$" "") str/trim)
+        budget (- limit m)
+        lines  (pack-words (str/split body #"\s+") budget)]
+    (if (> (count lines) 1)
+      (let [[first-line & rest] lines
+            zloc' (z/replace* zloc (n/comment-node (str "; " (str/join " " first-line))))
+            last' (reduce (fn [z line]
+                            (-> z
+                                (z/insert-right* (n/newlines 1))
+                                z/right*
+                                (z/insert-right* (whitespace m))
+                                z/right*
+                                (z/insert-right* (n/comment-node (str "; " (str/join " " line))))
+                                z/right*))
+                          zloc' rest)]
+        (if nl?
+          (z/insert-right* last' (n/newlines 1))
+          last'))
+      zloc)))
+
+(defn- break-comments [form limit]
+  (z/root (edit-all (z/of-node* form)
+                    #(and (comment? %) (>= (current-line-width %) limit))
+                    #(wrap-comment % limit))))
+
+(def ^:private param-binding-symbols
+  #{'fn 'fn* 'bound-fn})
+
+(def ^:private pair-binding-symbols
+  #{'let 'let* 'loop 'loop* 'for 'doseq 'dotimes
+    'if-let 'when-let 'if-some 'when-some 'binding
+    'with-open 'with-local-vars 'with-redefs})
+
+(defn- defn-form? [zloc]
+  (and (z/list? zloc)
+       (contains? def-docstring-symbols (z/sexpr (z/down zloc)))))
+
+(defn- binding-form? [zloc]
+  (and (z/list? zloc)
+       (contains? (into param-binding-symbols pair-binding-symbols)
+                  (z/sexpr (z/down zloc)))))
+
+(defn- line-start? [zloc]
+  (-> zloc prior-line-string last-line-in-string str/blank?))
+
+(defn- arity-list? [zloc]
+  (and (z/list? zloc)
+       (when-let [gp (z/up* zloc)]
+         (and (defn-form? gp)
+              (> (index-of zloc) 1)
+              (z/vector? (z/down zloc))))))
+
+(defn- params-vector? [zloc]
+  (and (z/vector? zloc)
+       (let [parent (z/up* zloc)
+             i      (index-of zloc)]
+         (if (defn-form? parent)
+           (or (= i 2)
+               (and (= i 3)
+                    (string-token? (-> parent z/down z/right z/right))))
+           (and (arity-list? parent) (= i 0))))))
+
+(defn- arity-body? [zloc]
+  (and (= (index-of zloc) 1)
+       (arity-list? (z/up* zloc))))
+
+(defn- single-arity-body? [zloc]
+  (when-let [parent (z/up* zloc)]
+    (let [after-name (-> parent z/down z/right z/right)
+          doc?       (string-token? after-name)
+          i          (index-of zloc)]
+      (and (defn-form? parent)
+           (z/vector? (if doc? (z/right after-name) after-name))
+           (or (and (not doc?) (= i 3))
+               (and doc? (= i 4)))))))
+
+(defn- binding-vector? [zloc]
+  (and (z/vector? zloc)
+       (when-let [parent (z/up* zloc)]
+         (and (binding-form? parent) (= (index-of zloc) 1)))))
+
+(defn- binding-body? [zloc]
+  (and (= (index-of zloc) 2)
+       (binding-form? (z/up* zloc))))
+
+(defn- break-before [zloc]
+  (let [left (z/left* zloc)]
+    (if (z/whitespace? left)
+      (z/replace* left (n/newlines 1))
+      (z/insert-left* zloc (n/newlines 1)))))
+
+(defn- break-defn-vector [form limit]
+  (-> form
+      (transform edit-all
+                 (fn [zloc]
+                   (and (arity-body? zloc)
+                        (>= (current-line-width (z/up* zloc)) limit)
+                        (not (line-start? zloc))))
+                 break-before)
+      (transform edit-all
+                 (fn [zloc]
+                   (and (single-arity-body? zloc)
+                        (not (str/includes? (z/string (z/up* zloc)) "\n"))
+                        (>= (current-line-width zloc) limit)))
+                 break-before)
+      (transform edit-all
+                 (fn [zloc]
+                   (and (params-vector? zloc)
+                        (>= (current-line-width zloc) limit)
+                        (not (line-start? zloc))))
+                 break-before)))
+
+(defn- break-each-vector [zloc group-size]
+  (loop [z (z/down zloc)
+         in-group 0]
+    (if z
+      (if (z/whitespace? z)
+        (recur (z/right* z) in-group)
+        (let [next (inc in-group)
+              nxt  (z/right* z)]
+          (if (or (nil? nxt)
+                  (and (z/whitespace? nxt) (nil? (z/right nxt))))
+            z
+            (if (= next group-size)
+              (let [sep (z/right* z)
+                    z   (if (z/whitespace? sep)
+                          (z/replace* sep (n/newlines 1))
+                          (z/insert-left* sep (n/newlines 1)))]
+                (recur (if (z/whitespace? sep) (z/right* z) z) 0))
+              (recur (z/right* z) next)))))
+      z)))
+
+(defn- break-defn-each [form limit]
+  (transform form edit-all
+             #(and (params-vector? %) (>= (count (z/string %)) limit))
+             #(break-each-vector % 1)))
+
+(defn- break-binding-vector [form limit]
+  (transform form edit-all
+             (fn [zloc]
+               (and (binding-body? zloc)
+                    (>= (current-line-width (z/up* zloc)) limit)
+                    (not (line-start? zloc))))
+             break-before))
+
+(defn- break-binding-each [form limit]
+  (transform form edit-all
+             (fn [zloc]
+               (and (binding-vector? zloc)
+                    (>= (count (z/string zloc)) limit)))
+             (fn [zloc]
+               (let [form-sym (-> zloc z/up* z/down z/sexpr)]
+                 (break-each-vector zloc (if (contains? param-binding-symbols form-sym) 1 2))))))
+
+(defn- break-defn-params [form {:keys [break-vector break-each]}]
+  (-> form
+      (cond-> break-vector (break-defn-vector break-vector))
+      (cond-> break-each    (break-defn-each break-each))))
+
+(defn- break-binding-forms [form {:keys [break-vector break-each]}]
+  (-> form
+      (cond-> break-vector (break-binding-vector break-vector))
+      (cond-> break-each    (break-binding-each break-each))))
+
+(defn- break-long-lines [form opts]
+  (let [{:keys [doc-strings comments defn-params binding-forms]}
+        (:break-on opts)]
+    (-> form
+        (cond-> doc-strings  (break-doc-strings doc-strings))
+        (cond-> comments     (break-comments comments))
+        (cond-> defn-params  (break-defn-params defn-params))
+        (cond-> binding-forms (break-binding-forms binding-forms)))))
 
 (def ^:private ns-reference-symbols
   #{:import :require :require-macros :use})
@@ -917,6 +1145,8 @@
            insert-missing-whitespace)
          (cond-> (:remove-multiple-non-indenting-spaces? opts)
            remove-multiple-non-indenting-spaces)
+         (cond-> (seq (:break-on opts))
+           (break-long-lines opts))
          (cond-> (:indentation? opts)
            (reindent indents opts))
          (cond-> (:align-map-columns? opts)

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -3301,6 +3301,164 @@
          {:align-map-columns?       true
           :max-column-alignment-gap 5}))))
 
+(deftest test-break-long-lines
+  (testing "doc strings"
+    (testing "breaks long doc string at word boundary"
+      (is (reformats-to?
+           ["(defn foo"
+            "  \"AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF GGGGG\""
+            "  [x]"
+            "  x)"]
+           ["(defn foo"
+            "  \"AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF"
+            "  GGGGG\""
+            "  [x]"
+            "  x)"]
+            {:break-on {:doc-strings 40}})))
+    (testing "short doc string not broken"
+      (is (reformats-to?
+           ["(defn foo"
+            "  \"short\""
+            "  [x]"
+            "  x)"]
+           ["(defn foo"
+            "  \"short\""
+            "  [x]"
+            "  x)"]
+            {:break-on {:doc-strings 40}})))
+    (testing "disabled without :doc-strings"
+      (is (reformats-to?
+           ["(defn foo"
+            "  \"AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF GGGGG\""
+            "  [x]"
+            "  x)"]
+           ["(defn foo"
+            "  \"AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF GGGGG\""
+            "  [x]"
+            "  x)"]
+           {:break-on {}}))))
+
+  (testing "comments"
+    (testing "breaks long comment at word boundary"
+      (is (reformats-to?
+           [";; AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF GGGGG HHHHH"]
+           [";; AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF"
+            ";; GGGGG HHHHH"]
+            {:break-on {:comments 40}})))
+    (testing "short comment not broken"
+      (is (reformats-to?
+           [";; short"]
+           [";; short"]
+            {:break-on {:comments 40}})))
+    (testing "disabled without :comments"
+      (is (reformats-to?
+           [";; AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF GGGGG HHHHH"]
+           [";; AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF GGGGG HHHHH"]
+           {:break-on {}}))))
+
+  (testing "defn params"
+    (testing "break-vector moves [] to its own line when line exceeds limit"
+      (is (reformats-to?
+           ["(defn my-long-function [alpha beta gamma delta]"
+            "  body)"]
+           ["(defn my-long-function"
+            "  [alpha beta gamma delta]"
+            "  body)"]
+            {:break-on {:defn-params {:break-vector 40}}})))
+    (testing "already on own line: no change"
+      (is (reformats-to?
+           ["(defn my-long-function"
+            "  [alpha beta gamma delta]"
+            "  body)"]
+           ["(defn my-long-function"
+            "  [alpha beta gamma delta]"
+            "  body)"]
+            {:break-on {:defn-params {:break-vector 40}}})))
+    (testing "within limit: no change"
+      (is (reformats-to?
+           ["(defn f [x] body)"]
+           ["(defn f [x] body)"]
+            {:break-on {:defn-params {:break-vector 40}}})))
+    (testing "break-each breaks params to individual lines"
+      (is (reformats-to?
+           ["(defn f [alpha beta gamma delta epsilon]"
+            "  body)"]
+           ["(defn f"
+            "  [alpha"
+            "   beta"
+            "   gamma"
+            "   delta"
+            "   epsilon]"
+            "  body)"]
+            {:break-on {:defn-params {:break-vector 40
+                                       :break-each 20}}})))
+    (testing "multi-arity: breaks all arities"
+      (is (reformats-to?
+           ["(defn foo"
+            "  ([alpha beta] body)"
+            "  ([alpha beta gamma delta epsilon] body2))"]
+           ["(defn foo"
+            "  ([alpha beta] body)"
+            "  ([alpha beta gamma delta epsilon]"
+            "   body2))"]
+            {:break-on {:defn-params {:break-vector 40}}})))
+    (testing "defn- params broken"
+      (is (reformats-to?
+           ["(defn- my-longer-name [alpha beta gamma delta] body)"]
+           ["(defn- my-longer-name"
+            "  [alpha beta gamma delta]"
+            "  body)"]
+            {:break-on {:defn-params {:break-vector 40}}}))))
+
+
+  (testing "binding forms"
+    (testing "fn break-vector moves body to new line"
+      (is (reformats-to?
+           ["(fn [alpha beta gamma delta] (+ alpha beta gamma delta))"]
+           ["(fn [alpha beta gamma delta]"
+            "  (+ alpha beta gamma delta))"]
+            {:break-on {:binding-forms {:break-vector 30}}})))
+    (testing "fn break-each breaks params to individual lines"
+      (is (reformats-to?
+           ["(fn [alpha beta gamma delta epsilon] body)"]
+           ["(fn [alpha"
+            "     beta"
+            "     gamma"
+            "     delta"
+            "     epsilon]"
+            "  body)"]
+            {:break-on {:binding-forms {:break-vector 30
+                                        :break-each 15}}})))
+    (testing "let break-vector moves body to new line"
+      (is (reformats-to?
+           ["(let [alpha 1 beta 2 gamma 3] (+ alpha beta gamma))"]
+           ["(let [alpha 1 beta 2 gamma 3]"
+            "  (+ alpha beta gamma))"]
+            {:break-on {:binding-forms {:break-vector 30}}})))
+    (testing "let break-each breaks pairs to individual lines"
+      (is (reformats-to?
+           ["(let [alpha 1 beta 2 gamma 3] body)"]
+           ["(let [alpha 1"
+            "      beta 2"
+            "      gamma 3]"
+            "  body)"]
+            {:break-on {:binding-forms {:break-vector 30
+                                        :break-each 15}}})))
+    (testing "within limit: no change"
+      (is (reformats-to?
+           ["(fn [x] x)"]
+           ["(fn [x] x)"]
+            {:break-on {:binding-forms {:break-vector 40}}}))))
+
+
+  (testing "disabled when no break-on keys match"
+    (is (reformats-to?
+         ["(defn my-long-function-name [alpha beta gamma delta epsilon zeta]"
+          "  body)"]
+         ["(defn my-long-function-name [alpha beta gamma delta epsilon zeta]"
+          "  body)"]
+         {:break-on {:doc-strings 40}}))))
+
 (deftest test-realign-form
   (is (= "
 {:x   1

--- a/cljfmt/test/cljfmt/core_test.cljc
+++ b/cljfmt/test/cljfmt/core_test.cljc
@@ -3345,6 +3345,37 @@
            [";; AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF"
             ";; GGGGG HHHHH"]
             {:break-on {:comments 40}})))
+    (testing "breaks comment preceding a form"
+      (is (reformats-to?
+           [";; AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF GGGGG HHHHH"
+            "(defn foo [x] x)"]
+           [";; AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF"
+            ";; GGGGG HHHHH"
+            "(defn foo [x] x)"]
+            {:break-on {:comments 40}})))
+    (testing "breaks indented comment without losing following code"
+      (is (reformats-to?
+           ["(defn foo"
+            "  (let [x 1]"
+            "    ;; AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF GGGGG HHHHH"
+            "    x))"]
+           ["(defn foo"
+            "  (let [x 1]"
+            "    ;; AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF"
+            "    ;; GGGGG HHHHH"
+            "    x))"]
+            {:break-on {:comments 40}})))
+    (testing "breaks long comment over multiple continuation lines"
+      (is (reformats-to?
+           ["(defn foo"
+            "  ;; AAAAA BBBBB CCCCC DDDDD EEEEE FFFFF GGGGG HHHHH IIIII"
+            "  x)"]
+           ["(defn foo"
+            "  ;; AAAAA BBBBB CCCCC DDDDD"
+            "  ;; EEEEE FFFFF GGGGG HHHHH"
+            "  ;; IIIII"
+            "  x)"]
+            {:break-on {:comments 25}})))
     (testing "short comment not broken"
       (is (reformats-to?
            [";; short"]


### PR DESCRIPTION
@weavejester A proof of concept for line breaking.  Don't really review the code its llm slop.  If this is seems useful I will go do a real code change.  Let me know if you have any comments on the general concept.

BTW if you have access to actions I have several examples we could use to craft some auto checking of the details you have to look at like line length this pr is adding the fmt for.

> [!WARNING]
> **Demo / proof-of-concept code — NOT ready for release.**
> This branch is experimental exploration of a `:break-on` formatting option for
> cljfmt. It is **not** intended to be merged as-is. The option shape, threshold
> semantics, and edge-case behavior are all likely to change. No CHANGELOG entry,
> no docs polish, minimal test coverage. Review at your own risk.

## What it does

Adds a new `:break-on` formatting option that reflows long lines at word boundaries.

Supported entry shapes:

- `:break-on {:doc-strings N}` — reflow long `defn`/`defn-`/`defmacro` docstrings
  onto continuation lines, preserving the docstring's indentation.
- `:break-on {:comments N}` — reflow long `;;` comments onto continuation lines.
- `:break-on {:defn-params {:break-vector N :break-each N}}` — move a defn's
  parameter vector (or an arity's) onto its own line when the line exceeds `N`
  chars (`:break-each` puts each param on its own line).
- `:break-on {:binding-forms {:break-vector N :break-each N}}` — same for
  `fn`/`fn*`/`bound-fn` params and `let`/`loop`/`for`/`if-let`/`when-let`
  `if-some`/`when-some`/`binding`/`with-open`/`with-local-vars`/`with-redefs`
  /`doseq`/`dotimes` binding pairs.

All checks are width-based (line length `>=` the threshold), applied in the
`reformat-form` pipeline between whitespace normalization and reindentation.

## Examples

**`:doc-strings`** (limit 40)

```clojure
:break-on {:doc-strings 40}
```

```clojure
;; before
(defn my-function
  "This docstring explains the function and its behavior in a lot of detail."
  [x]
  x)

;; after
(defn my-function
  "This docstring explains the function
  and its behavior in a lot of detail."
  [x]
  x)
```

**`:comments`** (limit 40)

```clojure
:break-on {:comments 40}
```

```clojure
;; before
;; This comment line is long and should wrap onto the next line.
(defn foo [x] x)

;; after
;; This comment line is long and should
;; wrap onto the next line.
(defn foo [x] x)
```

**`:defn-params` `:break-vector`** (limit 40)

```clojure
:break-on {:defn-params {:break-vector 40}}
```

```clojure
;; before
(defn my-long-function [alpha beta gamma delta] body)

;; after
(defn my-long-function
  [alpha beta gamma delta]
  body)
```

**`:defn-params` `:break-each`** (limit 15)

```clojure
:break-on {:defn-params {:break-each 15}}
```

```clojure
;; before
(defn my-function [alpha beta gamma] body)

;; after
(defn my-function [alpha
                   beta
                   gamma] body)
```

**`:binding-forms` `:break-vector`** (limit 30)

```clojure
:break-on {:binding-forms {:break-vector 30}}
```

```clojure
;; before
(let [alpha 1 beta 2 gamma 3] (+ alpha beta gamma))

;; after
(let [alpha 1 beta 2 gamma 3]
  (+ alpha beta gamma))
```

**`:binding-forms` `:break-each`** (limit 15)

```clojure
:break-on {:binding-forms {:break-each 15}}
```

```clojure
;; before
(let [alpha 1 beta 2 gamma 3] body)

;; after
(let [alpha 1
      beta 2
      gamma 3] body)
```

**`:binding-forms` with `fn`** (limits 20 / 10)

```clojure
:break-on {:binding-forms {:break-vector 20, :break-each 10}}
```

```clojure
;; before
(map (fn [alpha beta] (+ alpha beta)) items)

;; after (break-vector)
(map (fn [alpha beta]
       (+ alpha beta)) items)

;; after (break-each)
(map (fn [alpha
          beta] (+ alpha beta)) items)
```

## Notes / caveats

- Thresholds are approximate — measured on the rendered line (margin + content),
  not a configured wrap column.
- `:break-each` thresholds are gated on the params/binding **vector's own length**
  (e.g. `[alpha beta gamma]`), not the whole line.
- Only forms matching the known symbol lists are handled; no user-extensible
  symbol sets yet.
- Comments: continuation lines align to the original comment's margin; inline
  comments after code are also candidates for wrapping.
- No support for `:break-on` in `.cljfmt.edn` config schema yet beyond a
  (minimal) spec in `config.clj`.
- Idempotency is verified for the covered cases but the suite is small.
